### PR TITLE
Web Panels - the fork's work, rebased on main (MPL-2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.zip
 dist/
 node_modules/
+
+# patch(1) leftovers
+*.orig
+*.rej

--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ The mod is currently Zen-only. Other Firefox-family browsers would need a separa
 ## Preferences
 
 - `sine.web-panels.enabled`: enables or disables the rail.
-- `sine.web-panels.resizer-color`: colour of the resize handle. Empty follows
-  the browser theme, which is the default and the way back — `Reset handle
-  colour` in the rail context menu clears it.
+- `sine.web-panels.resizer-color`: colour of the resize handle, as any CSS
+  colour. Empty follows the browser theme, which is both the default and the
+  way back — clearing the field restores it.
 - `sine.web-panels.collapsed`: how the rail was last left. Collapsing is
   per-window; this only seeds new windows and the next session. Not the same as
   disabling the rail — collapsed, every panel stays loaded.
-- `sine.web-panels.width`: remembered floating panel width.
+- `sine.web-panels.width`: remembered floating panel width. Set by dragging the
+  panel's edge; not exposed as a settings field, since the edge is the better
+  control.
 - `sine.web-panels.items`: JSON list of panel and separator items.
 
 ## Validate

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ The mod is currently Zen-only. Other Firefox-family browsers would need a separa
   control.
 - `sine.web-panels.items`: JSON list of panel and separator items.
 
+## Tests
+
+```bash
+node --test scripts/tests/*.mjs
+```
+
+`scripts/tests/helpers/chrome-window.mjs` is a fake chrome window — DOM, prefs,
+observers, `gBrowser` and a hand-pumped clock — complete enough to mount the
+real controller against. The tests drive the actual class through it rather
+than asserting on the source text, so a rename does not fail them and a broken
+behaviour does not pass them.
+
 ## Validate
 
 Run the static package checks before publishing:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Version `0.4.0` is Zen-only. It uses Zen-managed hidden tabs and Zen browser con
 - Spacer items with move/delete context menu.
 - Drag reorder across panels and spacers.
 - Unread count badge from title prefixes such as `(3) Inbox` or `[3] Inbox`.
+- Panel tabs are reclaimed after a browser restart rather than coming back as
+  ordinary tabs, using a session-store marker that survives one.
 - Clean Sine unload handling for DOM, listeners, and live managed panel tabs.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The mod is currently Zen-only. Other Firefox-family browsers would need a separa
 ## Preferences
 
 - `sine.web-panels.enabled`: enables or disables the rail.
+- `sine.web-panels.resizer-color`: colour of the resize handle. Empty follows
+  the browser theme, which is the default and the way back — `Reset handle
+  colour` in the rail context menu clears it.
 - `sine.web-panels.collapsed`: how the rail was last left. Collapsing is
   per-window; this only seeds new windows and the next session. Not the same as
   disabling the rail — collapsed, every panel stays loaded.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Version `0.4.0` is Zen-only. It uses Zen-managed hidden tabs and Zen browser con
 - Tab context-menu action to add the clicked web tab to Web Panels.
 - Floating panel surface that opens above the page without resizing it.
 - Managed hidden-tab runtime for extension-compatible panel pages.
+- Collapse the rail to a hover edge: a toggle at the top of the rail, the same
+  shortcut modifier + `B`, or `Hide the rail` in the rail context menu. Hidden,
+  it gives its strip of window back and slides in over the page while the
+  pointer rests at that window edge.
 - Outside-click and Escape dismissal.
 - Resizable panel with a `320px` minimum width.
 - Panel context menu: open in new tab, edit, move, unload, delete.
@@ -38,6 +42,9 @@ The mod is currently Zen-only. Other Firefox-family browsers would need a separa
 ## Preferences
 
 - `sine.web-panels.enabled`: enables or disables the rail.
+- `sine.web-panels.collapsed`: how the rail was last left. Collapsing is
+  per-window; this only seeds new windows and the next session. Not the same as
+  disabling the rail — collapsed, every panel stays loaded.
 - `sine.web-panels.width`: remembered floating panel width.
 - `sine.web-panels.items`: JSON list of panel and separator items.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Version `0.4.0` is Zen-only. It uses Zen-managed hidden tabs and Zen browser con
 
 - Persistent web panel URLs stored in `sine.web-panels.items`.
 - Favicon rail with a bottom `+` button.
-- URL-only add/edit popup with validation for `http` and `https`.
+- URL-only Add popup with validation for `http` and `https`; Edit (right-click a panel) adds an optional name, for when two accounts on one site would otherwise look the same.
 - Tab context-menu action to add the clicked web tab to Web Panels.
 - Floating panel surface that opens above the page without resizing it.
 - Managed hidden-tab runtime for extension-compatible panel pages.

--- a/preferences.json
+++ b/preferences.json
@@ -44,5 +44,16 @@
         "label": "Alt / ⌥ + Shift + 1…0"
       }
     ]
+  },
+  {
+    "type": "separator",
+    "label": "Appearance"
+  },
+  {
+    "type": "string",
+    "label": "Resize handle colour — leave empty to follow the browser theme",
+    "property": "sine.web-panels.resizer-color",
+    "defaultValue": "",
+    "placeholder": "#3b82f6, rebeccapurple, oklch(0.7 0.2 250)…"
   }
 ]

--- a/preferences.json
+++ b/preferences.json
@@ -6,13 +6,6 @@
     "defaultValue": true
   },
   {
-    "type": "string",
-    "label": "Panel width",
-    "property": "sine.web-panels.width",
-    "defaultValue": "420",
-    "placeholder": "420"
-  },
-  {
     "type": "dropdown",
     "label": "Panel shortcut",
     "property": "sine.web-panels.shortcut-modifier",

--- a/preferences.json
+++ b/preferences.json
@@ -16,7 +16,7 @@
     "type": "dropdown",
     "label": "Panel shortcut",
     "property": "sine.web-panels.shortcut-modifier",
-    "defaultValue": "ctrl+alt",
+    "defaultValue": "accel+alt",
     "placeholder": false,
     "options": [
       {
@@ -24,24 +24,24 @@
         "label": "Disabled"
       },
       {
-        "value": "ctrl",
-        "label": "Ctrl + 1…0"
+        "value": "accel",
+        "label": "Ctrl / ⌘ + 1…0"
       },
       {
-        "value": "ctrl+alt",
-        "label": "Ctrl + Alt + 1…0"
+        "value": "accel+alt",
+        "label": "Ctrl / ⌘ + Alt / ⌥ + 1…0"
       },
       {
-        "value": "ctrl+shift",
-        "label": "Ctrl + Shift + 1…0"
+        "value": "accel+shift",
+        "label": "Ctrl / ⌘ + Shift + 1…0"
       },
       {
         "value": "alt",
-        "label": "Alt + 1…0"
+        "label": "Alt / ⌥ + 1…0"
       },
       {
         "value": "alt+shift",
-        "label": "Alt + Shift + 1…0"
+        "label": "Alt / ⌥ + Shift + 1…0"
       }
     ]
   }

--- a/preferences.json
+++ b/preferences.json
@@ -11,5 +11,38 @@
     "property": "sine.web-panels.width",
     "defaultValue": "420",
     "placeholder": "420"
+  },
+  {
+    "type": "dropdown",
+    "label": "Panel shortcut",
+    "property": "sine.web-panels.shortcut-modifier",
+    "defaultValue": "ctrl+alt",
+    "placeholder": false,
+    "options": [
+      {
+        "value": "disabled",
+        "label": "Disabled"
+      },
+      {
+        "value": "ctrl",
+        "label": "Ctrl + 1…0"
+      },
+      {
+        "value": "ctrl+alt",
+        "label": "Ctrl + Alt + 1…0"
+      },
+      {
+        "value": "ctrl+shift",
+        "label": "Ctrl + Shift + 1…0"
+      },
+      {
+        "value": "alt",
+        "label": "Alt + 1…0"
+      },
+      {
+        "value": "alt+shift",
+        "label": "Alt + Shift + 1…0"
+      }
+    ]
   }
 ]

--- a/scripts/tests/controller.test.mjs
+++ b/scripts/tests/controller.test.mjs
@@ -6,6 +6,7 @@ const PREFS = {
   enabled: "sine.web-panels.enabled",
   collapsed: "sine.web-panels.collapsed",
   width: "sine.web-panels.width",
+  items: "sine.web-panels.items",
 };
 
 // The controller reads globalThis.Services at import time, and createChromeWindow
@@ -223,4 +224,156 @@ test("a colour that could escape the declaration never reaches the DOM", () => {
   app.prefs.setStringPref("sine.web-panels.resizer-color", "red; background: url(x)");
 
   assert.equal(app.document.documentElement.style.has("--sine-web-panels-accent"), false);
+});
+
+// --------------------------------------------------------------------------
+// The window must never rest on a panel's backing tab. Two ways it got there:
+// restoring a session saved with a panel open, and picking the panel's own
+// site out of the address bar — UrlbarProviderOpenTabs does not filter hidden
+// tabs, so backings are offered as switch-to-tab candidates. Once there, the
+// page fills the window with no panel around it and no panel will open at all.
+// --------------------------------------------------------------------------
+
+// The harness's selectedTab fires TabSelect on assignment, as the browser's
+// does, so selecting a tab below is the whole gesture.
+
+test("selecting a panel's backing tab hands the window straight back", () => {
+  const app = mount();
+  const ordinary = app.addTab();
+  const backing = app.addTab({ panelId: "panel-1", hidden: true });
+
+  app.window.gBrowser.selectedTab = backing;
+
+  assert.equal(
+    app.window.gBrowser.selectedTab,
+    ordinary,
+    "the window cannot be left displaying a backing tab"
+  );
+});
+
+test("an ordinary tab is left selected", () => {
+  const app = mount();
+  const first = app.addTab();
+  const second = app.addTab();
+
+  app.window.gBrowser.selectedTab = second;
+
+  assert.equal(app.window.gBrowser.selectedTab, second, "no meddling");
+  assert.notEqual(app.window.gBrowser.selectedTab, first);
+});
+
+test("the recovery holds when the backing is the tab a search landed on", () => {
+  // Same invariant from the other entrance: no restart involved, the address
+  // bar simply offered a hidden backing as a switch-to-tab candidate.
+  const app = mount();
+  app.addTab();
+  const backing = app.addTab({ panelId: "panel-1", hidden: true });
+
+  app.window.gBrowser.selectedTab = backing;
+  // And again, in case the first correction is itself re-overridden — session
+  // restore re-selects its own idea of the selected tab after we have run.
+  app.window.gBrowser.selectedTab = backing;
+
+  assert.notEqual(app.window.gBrowser.selectedTab, backing);
+});
+
+test("correcting the selection cannot set off another correction", () => {
+  // The regression this pins: the guard used to open the panel it had just
+  // taken the selection from. #openSurface selects that panel's tab on
+  // purpose, and #activeId is only set after it returns, so the TabSelect
+  // that fired looked like another stray backing — and round it went. Zen
+  // crawled and every panel stopped working.
+  const app = mount();
+  const ordinary = app.addTab();
+  const backing = app.addTab({ panelId: "panel-1", hidden: true });
+
+  let selections = 0;
+  const gBrowser = app.window.gBrowser;
+  let current = backing;
+  // Counting every assignment is the point here, so the harness's own
+  // accessor is replaced by one that also keeps score.
+  Object.defineProperty(gBrowser, "selectedTab", {
+    configurable: true,
+    get: () => current,
+    set(tab) {
+      current = tab;
+      selections += 1;
+      assert.ok(selections < 10, "the guard is looping");
+      gBrowser.tabContainer.dispatch("TabSelect", { target: tab });
+    },
+  });
+
+  gBrowser.tabContainer.dispatch("TabSelect", { target: backing });
+
+  assert.equal(gBrowser.selectedTab, ordinary);
+  assert.ok(selections <= 2, `settled in ${selections} selection(s)`);
+});
+
+// --------------------------------------------------------------------------
+// Opening a panel selects its backing tab on purpose — that is how extensions
+// resolve the panel's site. The guard above must recognise that as the
+// controller's own doing, or it undoes every panel the moment it opens: the
+// TabSelect it fires arrives before #activeId is assigned, so to the guard the
+// backing looked stray, and the window was handed to the first ordinary tab
+// instead. Every panel "opened" whatever tab happened to be first in the strip.
+// --------------------------------------------------------------------------
+
+function mountWithPanels(urls) {
+  const items = urls.map((url, index) => ({ type: "panel", id: `panel-${index + 1}`, url }));
+  const app = mount({ prefs: { [PREFS.items]: JSON.stringify(items) } });
+  const ordinary = app.addTab({ url: "https://plane.example/", select: true });
+  return { app, ordinary, items };
+}
+
+function railButton(app, id) {
+  return app.root().querySelector(`[data-item-id="${id}"]`);
+}
+
+test("opening a panel from the rail leaves it open, on its own tab", () => {
+  const { app, ordinary } = mountWithPanels(["https://mail.example/"]);
+
+  railButton(app, "panel-1").dispatch("click");
+
+  const selected = app.window.gBrowser.selectedTab;
+  assert.equal(app.root().getAttribute("open"), "true", "the panel is open");
+  assert.equal(app.root().getAttribute("active"), "panel-1");
+  assert.equal(selected.getAttribute("sine-web-panel-id"), "panel-1", "its backing holds the selection");
+  assert.notEqual(selected, ordinary, "the window was not handed back to the first ordinary tab");
+  assert.ok(
+    selected.linkedPanel.classList.contains("sine-web-panels-overlay"),
+    "and its container is the overlay"
+  );
+});
+
+test("switching panels moves the selection to the new panel's tab", () => {
+  const { app, ordinary } = mountWithPanels(["https://mail.example/", "https://plane.example/app"]);
+
+  railButton(app, "panel-1").dispatch("click");
+  railButton(app, "panel-2").dispatch("click");
+
+  const selected = app.window.gBrowser.selectedTab;
+  assert.equal(app.root().getAttribute("active"), "panel-2");
+  assert.equal(selected.getAttribute("sine-web-panel-id"), "panel-2");
+  assert.notEqual(selected, ordinary);
+});
+
+test("closing a panel hands the window back to the tab it opened over", () => {
+  const { app, ordinary } = mountWithPanels(["https://mail.example/"]);
+
+  railButton(app, "panel-1").dispatch("click");
+  railButton(app, "panel-1").dispatch("click");
+  app.advance(100);
+
+  assert.equal(app.root().hasAttribute("open"), false);
+  assert.equal(app.window.gBrowser.selectedTab, ordinary);
+});
+
+test("a stray backing is still corrected while another panel is open", () => {
+  const { app } = mountWithPanels(["https://mail.example/"]);
+  const stray = app.addTab({ panelId: "panel-9", hidden: true });
+
+  railButton(app, "panel-1").dispatch("click");
+  app.window.gBrowser.selectedTab = stray;
+
+  assert.notEqual(app.window.gBrowser.selectedTab, stray);
 });

--- a/scripts/tests/controller.test.mjs
+++ b/scripts/tests/controller.test.mjs
@@ -377,3 +377,83 @@ test("a stray backing is still corrected while another panel is open", () => {
 
   assert.notEqual(app.window.gBrowser.selectedTab, stray);
 });
+
+// --------------------------------------------------------------------------
+// The navigation controls live in the panel's frame and act on its browser.
+// --------------------------------------------------------------------------
+
+function navOf(app) {
+  return app.window.gBrowser.selectedTab.linkedPanel.querySelector(".sine-web-panels-nav");
+}
+
+test("opening a panel mounts back, forward, reload and home beside it", () => {
+  const { app } = mountWithPanels(["https://mail.example/"]);
+
+  railButton(app, "panel-1").dispatch("click");
+
+  const nav = navOf(app);
+  assert.ok(nav, "the controls are in the panel frame");
+  assert.equal(nav.getAttribute("aria-orientation"), "vertical");
+  assert.deepEqual(
+    [...nav.querySelectorAll(".sine-web-panels-nav-button")].map(button => button.getAttribute("aria-label")),
+    ["Back", "Forward", "Reload", "Home (reset this panel)"]
+  );
+  assert.equal(nav.querySelector(".sine-web-panels-nav-back").disabled, true, "no history yet");
+  assert.equal(nav.querySelector(".sine-web-panels-nav-forward").disabled, true);
+});
+
+test("back and forward follow the panel browser's history", () => {
+  const { app } = mountWithPanels(["https://mail.example/"]);
+  railButton(app, "panel-1").dispatch("click");
+
+  const browser = app.window.gBrowser.selectedTab.linkedBrowser;
+  const calls = [];
+  browser.canGoBack = true;
+  browser.goBack = () => calls.push("back");
+  browser.goForward = () => calls.push("forward");
+
+  const nav = navOf(app);
+  nav.querySelector(".sine-web-panels-nav-forward").dispatch("click");
+  assert.deepEqual(calls, [], "forward is a no-op with nothing ahead");
+
+  // The buttons re-read the state after every click, so the enabled state
+  // catches up with the browser's without a separate event.
+  nav.querySelector(".sine-web-panels-nav-back").dispatch("click");
+  assert.deepEqual(calls, ["back"]);
+  assert.equal(nav.querySelector(".sine-web-panels-nav-back").disabled, false);
+});
+
+test("home reloads the panel's configured URL and forgets where it drifted to", () => {
+  const { app } = mountWithPanels(["https://mail.example/"]);
+  app.prefs.setStringPref("sine.web-panels.last-urls", JSON.stringify({ "panel-1": "https://mail.example/thread/7" }));
+  railButton(app, "panel-1").dispatch("click");
+
+  const browser = app.window.gBrowser.selectedTab.linkedBrowser;
+  const loads = [];
+  browser.loadURI = uri => loads.push(uri.spec);
+
+  navOf(app).querySelector(".sine-web-panels-nav-home").dispatch("click");
+
+  assert.deepEqual(loads, ["https://mail.example/"]);
+  assert.equal(JSON.parse(app.prefs.getStringPref("sine.web-panels.last-urls"))["panel-1"], undefined);
+});
+
+test("reload refreshes the page the panel is on, without resetting it", () => {
+  const { app } = mountWithPanels(["https://mail.example/"]);
+  app.prefs.setStringPref("sine.web-panels.last-urls", JSON.stringify({ "panel-1": "https://mail.example/thread/7" }));
+  railButton(app, "panel-1").dispatch("click");
+
+  const browser = app.window.gBrowser.selectedTab.linkedBrowser;
+  let reloads = 0;
+  browser.reload = () => (reloads += 1);
+  browser.loadURI = () => assert.fail("reload must not navigate");
+
+  navOf(app).querySelector(".sine-web-panels-nav-reload").dispatch("click");
+
+  assert.equal(reloads, 1);
+  assert.equal(
+    JSON.parse(app.prefs.getStringPref("sine.web-panels.last-urls"))["panel-1"],
+    "https://mail.example/thread/7",
+    "where the panel was is kept"
+  );
+});

--- a/scripts/tests/controller.test.mjs
+++ b/scripts/tests/controller.test.mjs
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createChromeWindow } from "./helpers/chrome-window.mjs";
+
+const PREFS = {
+  enabled: "sine.web-panels.enabled",
+  collapsed: "sine.web-panels.collapsed",
+  width: "sine.web-panels.width",
+};
+
+// The controller reads globalThis.Services at import time, and createChromeWindow
+// installs it, so the harness has to exist before the module is pulled in.
+createChromeWindow();
+const { SineWebPanels } = await import("../web-panels.uc.mjs");
+
+// A real KeyboardEvent always carries every modifier as a boolean, and
+// shortcutMatches compares them strictly — so a partial event does not just
+// fail to match, it fails for the wrong reason.
+function keydown(code, modifiers = {}) {
+  return {
+    code,
+    key: "",
+    repeat: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    ...modifiers,
+  };
+}
+
+function mount(options = {}) {
+  const harness = createChromeWindow({
+    prefs: { [PREFS.enabled]: true, ...options.prefs },
+    viewportWidth: options.viewportWidth,
+  });
+  const controller = new SineWebPanels(harness.window);
+  controller.init();
+
+  return {
+    ...harness,
+    controller,
+    el: id => harness.document.getElementById(`sine-web-panels-${id}`),
+    root: () => harness.document.getElementById("sine-web-panels-root"),
+  };
+}
+
+test("mounting builds the rail and reserves a strip of window for it", () => {
+  const app = mount();
+
+  assert.ok(app.el("rail"), "the rail exists");
+  assert.ok(app.el("toggle"), "with the collapse toggle on it");
+  assert.equal(app.root().getAttribute("side"), "right");
+  assert.equal(app.browser.getAttribute("sine-web-panels-side"), "right");
+  assert.ok(
+    app.browser.style.getPropertyValue("--sine-web-panels-reserved-inline-size"),
+    "the content is inset by the rail's width"
+  );
+  assert.ok(app.appContent.style.has("margin-inline-end"), "on the rail's side");
+
+  app.controller.destroy();
+  assert.equal(app.root(), null, "and unloading leaves nothing behind");
+});
+
+test("a width stored from a wider window is clamped on the way in", () => {
+  // The regression: mount used to apply the stored width raw, so it overflowed
+  // until the first resize event happened to move it.
+  const app = mount({ prefs: { [PREFS.width]: "2009" }, viewportWidth: 1200 });
+
+  const applied = Number.parseInt(
+    app.document.documentElement.style.getPropertyValue("--sine-web-panels-width"),
+    10
+  );
+
+  assert.ok(applied < 2009, "clamped");
+  assert.ok(applied <= 1200, "to the page, not the window");
+  assert.equal(
+    app.prefs.getStringPref(PREFS.width),
+    "2009",
+    "but the stored width is left alone — clamping is for display only"
+  );
+});
+
+test("collapsing hands the reserved strip back and puts the hover edge up", () => {
+  const app = mount();
+  assert.equal(app.el("edge").hidden, true, "no edge while the rail is docked");
+
+  app.el("toggle").dispatch("click");
+
+  assert.ok(app.root().hasAttribute("collapsed"));
+  assert.equal(app.el("edge").hidden, false, "the edge is now the way back");
+  assert.equal(
+    app.browser.getAttribute("sine-web-panels-side"),
+    null,
+    "the reserved strip is released"
+  );
+  assert.equal(app.appContent.style.has("margin-inline-end"), false);
+
+  app.el("toggle").dispatch("click");
+
+  assert.equal(app.root().hasAttribute("collapsed"), false);
+  assert.ok(app.browser.style.getPropertyValue("--sine-web-panels-reserved-inline-size"));
+});
+
+test("collapsing is remembered for the next window, not broadcast to this one", () => {
+  const app = mount();
+
+  app.el("toggle").dispatch("click");
+  assert.equal(app.prefs.getBoolPref(PREFS.collapsed), true, "written for next time");
+
+  // What another window's toggle looks like from in here: the pref moves under
+  // us. This window must not follow it.
+  app.prefs.setBoolPref(PREFS.collapsed, false);
+  assert.ok(app.root().hasAttribute("collapsed"), "still collapsed");
+});
+
+test("a new window opens the way the rail was last left", () => {
+  const app = mount({ prefs: { [PREFS.collapsed]: true } });
+
+  assert.ok(app.root().hasAttribute("collapsed"));
+  assert.equal(app.el("edge").hidden, false);
+});
+
+test("the edge peeks the rail back in, and lets it go again", () => {
+  const app = mount({ prefs: { [PREFS.collapsed]: true } });
+
+  app.el("edge").dispatch("pointerenter");
+  assert.ok(app.root().hasAttribute("peeking"));
+
+  app.el("rail").dispatch("pointerleave");
+  assert.ok(app.root().hasAttribute("peeking"), "not the instant the pointer leaves");
+
+  app.advance(400);
+  assert.equal(app.root().hasAttribute("peeking"), false, "but shortly after");
+});
+
+test("the peek is held open while a menu is up, so the rail cannot slide away", () => {
+  const app = mount({ prefs: { [PREFS.collapsed]: true } });
+
+  app.el("edge").dispatch("pointerenter");
+  app.el("menu").hidden = false;
+  app.el("rail").dispatch("pointerleave");
+
+  app.advance(400);
+  assert.ok(app.root().hasAttribute("peeking"), "held");
+
+  app.el("menu").hidden = true;
+  app.advance(400);
+  assert.equal(app.root().hasAttribute("peeking"), false, "released");
+});
+
+test("fullscreen takes the rail off the screen and gives its strip back", () => {
+  const app = mount();
+
+  app.setRootAttribute("inFullscreen", "true");
+
+  assert.ok(app.root().hasAttribute("fullscreen"));
+  assert.equal(app.browser.getAttribute("sine-web-panels-side"), null);
+  assert.equal(app.appContent.style.has("margin-inline-end"), false);
+
+  app.setRootAttribute("inFullscreen", null);
+
+  assert.equal(app.root().hasAttribute("fullscreen"), false);
+  assert.ok(
+    app.browser.style.getPropertyValue("--sine-web-panels-reserved-inline-size"),
+    "and puts it back afterwards"
+  );
+});
+
+test("the rail moves when Zen's sidebar changes side", () => {
+  const app = mount();
+  assert.equal(app.root().getAttribute("side"), "right");
+  assert.ok(app.appContent.style.has("margin-inline-end"));
+
+  app.setRootAttribute("zen-right-side", "true");
+
+  assert.equal(app.root().getAttribute("side"), "left", "opposite Zen's sidebar");
+  assert.equal(app.browser.getAttribute("sine-web-panels-side"), "left");
+  assert.ok(app.appContent.style.has("margin-inline-start"), "the strip swaps sides");
+  assert.equal(app.appContent.style.has("margin-inline-end"), false, "and vacates the old one");
+});
+
+test("the configured shortcut toggles the rail", () => {
+  const app = mount();
+
+  app.document.dispatch("keydown", keydown("KeyB", { ctrlKey: true, altKey: true }));
+  assert.ok(app.root().hasAttribute("collapsed"));
+
+  app.document.dispatch("keydown", keydown("KeyB", { ctrlKey: true, altKey: true }));
+  assert.equal(app.root().hasAttribute("collapsed"), false);
+});
+
+test("the shortcut is dormant in fullscreen", () => {
+  const app = mount();
+  app.setRootAttribute("inFullscreen", "true");
+
+  app.document.dispatch("keydown", keydown("KeyB", { ctrlKey: true, altKey: true }));
+
+  assert.equal(
+    app.prefs.getBoolPref(PREFS.collapsed, false),
+    false,
+    "no invisible rail toggling behind a fullscreen video"
+  );
+});
+
+test("a custom handle colour is applied, and clearing it hands back to the theme", () => {
+  const app = mount({ prefs: { "sine.web-panels.resizer-color": "#3b82f6" } });
+  const root = app.document.documentElement;
+
+  assert.equal(root.style.getPropertyValue("--sine-web-panels-accent"), "#3b82f6");
+
+  app.prefs.setStringPref("sine.web-panels.resizer-color", "");
+  assert.equal(
+    root.style.has("--sine-web-panels-accent"),
+    false,
+    "removed, so the stylesheet's chain wins again"
+  );
+});
+
+test("a colour that could escape the declaration never reaches the DOM", () => {
+  const app = mount();
+
+  app.prefs.setStringPref("sine.web-panels.resizer-color", "red; background: url(x)");
+
+  assert.equal(app.document.documentElement.style.has("--sine-web-panels-accent"), false);
+});

--- a/scripts/tests/controller.test.mjs
+++ b/scripts/tests/controller.test.mjs
@@ -457,3 +457,83 @@ test("reload refreshes the page the panel is on, without resetting it", () => {
     "where the panel was is kept"
   );
 });
+
+// --------------------------------------------------------------------------
+// Add is one field and one click; the name lives in Edit.
+// --------------------------------------------------------------------------
+
+function editorOf(app) {
+  const editor = app.document.getElementById("sine-web-panels-editor");
+  return {
+    editor,
+    url: editor.querySelector("#sine-web-panels-url-input"),
+    name: editor.querySelector("#sine-web-panels-name-input"),
+    submit: editor.querySelector("#sine-web-panels-editor-submit"),
+    form: editor.querySelector("#sine-web-panels-editor-content"),
+  };
+}
+
+function items(app) {
+  return JSON.parse(app.prefs.getStringPref("sine.web-panels.items"));
+}
+
+test("Add asks for the URL and nothing else", () => {
+  const app = mount();
+  app.addTab({ url: "https://calendar.example/", select: true });
+
+  app.el("add-button").dispatch("click");
+
+  const { editor, url, name, submit } = editorOf(app);
+  assert.equal(editor.hidden, false);
+  assert.equal(editor.getAttribute("mode"), "add");
+  assert.equal(name.hidden, true, "no name field on Add");
+  assert.equal(submit.textContent, "Add");
+  assert.equal(url.value, "https://calendar.example/", "prefilled from the current tab");
+});
+
+test("a panel added from the popup carries no name, even after an Edit left one behind", () => {
+  const { app } = mountWithPanels(["https://mail.example/"]);
+  const { editor, url, name, form } = editorOf(app);
+
+  railButton(app, "panel-1").dispatch("contextmenu");
+  const edit = [...app.document.querySelectorAll(".sine-web-panels-menu-item")].find(
+    button => button.textContent === "Edit Web Panel"
+  );
+  edit.dispatch("click");
+  name.value = "Work";
+  form.dispatch("submit");
+
+  app.el("add-button").dispatch("click");
+  url.value = "https://calendar.example/";
+  form.dispatch("submit");
+
+  const added = items(app).find(item => item.url === "https://calendar.example/");
+  assert.ok(added, "the panel was added");
+  assert.equal(added.name, undefined);
+  assert.equal(editor.hidden, true, "the popup closed");
+});
+
+test("Edit shows the URL and the name together, and saves both", () => {
+  const { app } = mountWithPanels(["https://mail.example/"]);
+
+  railButton(app, "panel-1").dispatch("contextmenu");
+  const edit = [...app.document.querySelectorAll(".sine-web-panels-menu-item")].find(
+    button => button.textContent === "Edit Web Panel"
+  );
+  assert.ok(edit, "the context menu offers Edit");
+  edit.dispatch("click");
+
+  const { editor, url, name, submit, form } = editorOf(app);
+  assert.equal(editor.getAttribute("mode"), "edit");
+  assert.equal(name.hidden, false, "the name field is there");
+  assert.equal(url.value, "https://mail.example/");
+  assert.equal(submit.textContent, "Save");
+
+  name.value = "Personal";
+  url.value = "https://mail.example/u/1/";
+  form.dispatch("submit");
+
+  const [saved] = items(app);
+  assert.equal(saved.name, "Personal");
+  assert.equal(saved.url, "https://mail.example/u/1/");
+});

--- a/scripts/tests/css.test.mjs
+++ b/scripts/tests/css.test.mjs
@@ -52,3 +52,35 @@ test("the accent chain ends in a colour that cannot fail to resolve", () => {
   assert.match(root, /--zen-primary-color/, "prefers Zen's own theme colour");
   assert.match(root, /AccentColor\s*\)/, "falls back to the system accent");
 });
+
+// --------------------------------------------------------------------------
+// Navigation controls: Tom's condition for merging was that the gradient
+// header over the panel's content goes. His decision (2026-09-09): a few
+// floating controls beside the panel, always there, nothing appearing and
+// disappearing.
+// --------------------------------------------------------------------------
+
+test("the navigation controls float beside the panel, not over it", () => {
+  const nav = rule(".sine-web-panels-nav");
+
+  assert.doesNotMatch(nav, /gradient/, "no gradient");
+  assert.doesNotMatch(nav, /opacity:\s*0\b/, "not hidden until hovered");
+  assert.doesNotMatch(nav, /inset-inline:\s*0/, "does not span the panel's width");
+  assert.match(nav, /flex-direction:\s*column/, "a vertical stack");
+  assert.match(nav, /background:\s*var\(--zen-themed-toolbar-bg/, "opaque, themed");
+
+  const right = rule(':root[sine-web-panels-side="right"] .sine-web-panels-nav');
+  const left = rule(':root[sine-web-panels-side="left"] .sine-web-panels-nav');
+  assert.match(right, /inset-inline-end:\s*calc\(100%/, "outside the panel's edge on the right");
+  assert.match(left, /inset-inline-start:\s*calc\(100%/, "and on the left");
+  assert.match(right, /--sine-web-panels-resizer-width/, "clear of the resize handle");
+});
+
+test("the navigation controls do not come and go with the pointer", () => {
+  assert.doesNotMatch(css, /:hover\s*>\s*\.sine-web-panels-nav/);
+});
+
+test("the navigation controls leave when a panel's video goes fullscreen", () => {
+  const fullscreen = rule(":root[sine-web-panels-panel-fullscreen] .sine-web-panels-nav");
+  assert.match(fullscreen, /display:\s*none/);
+});

--- a/scripts/tests/css.test.mjs
+++ b/scripts/tests/css.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const css = readFileSync(
+  join(dirname(dirname(fileURLToPath(import.meta.url))), "web-panels.css"),
+  "utf8"
+);
+
+// Anchored at the start of a line, so a selector that also appears as the tail
+// of a compound rule elsewhere (`:root[inFullscreen] #sine-web-panels-resizer`)
+// cannot be mistaken for the standalone one.
+function rule(selector) {
+  const needle = `${selector} {`;
+  const start = css.startsWith(needle) ? 0 : css.indexOf(`\n${needle}`) + 1;
+  assert.ok(start > 0 || css.startsWith(needle), `missing rule: ${selector}`);
+  return css.slice(start, css.indexOf("}", start));
+}
+
+// The regression: the handle was pointer-events: none, so :hover could never
+// fire. Both sides of it are remote content, and chrome sees no pointer moves
+// over that, so the JS hover state alone left the affordance invisible.
+test("the resize handle stays hit-testable", () => {
+  const resizer = rule("#sine-web-panels-resizer");
+
+  assert.match(resizer, /pointer-events:\s*auto/);
+  assert.doesNotMatch(resizer, /pointer-events:\s*none/);
+  assert.match(resizer, /cursor:\s*ew-resize/, "the cursor is half the affordance");
+});
+
+test("the resize indicator spans the panel edge rather than a stub of it", () => {
+  const indicator = rule("#sine-web-panels-resizer::before");
+
+  assert.match(indicator, /inset-block:\s*0/);
+  assert.doesNotMatch(indicator, /height:\s*\d+px/, "no fixed height");
+});
+
+test("the resize indicator follows a theme colour, not a hard-coded one", () => {
+  const indicator = rule("#sine-web-panels-resizer::before");
+
+  assert.match(indicator, /background:\s*var\(--sine-web-panels-accent\)/);
+});
+
+// A var() chain that resolves to nothing paints nothing, which is exactly the
+// failure being fixed — so the last link must be a colour that always exists.
+test("the accent chain ends in a colour that cannot fail to resolve", () => {
+  const root = rule(":root");
+
+  assert.match(root, /--sine-web-panels-accent:/);
+  assert.match(root, /--zen-primary-color/, "prefers Zen's own theme colour");
+  assert.match(root, /AccentColor\s*\)/, "falls back to the system accent");
+});

--- a/scripts/tests/css.test.mjs
+++ b/scripts/tests/css.test.mjs
@@ -84,3 +84,60 @@ test("the navigation controls leave when a panel's video goes fullscreen", () =>
   const fullscreen = rule(":root[sine-web-panels-panel-fullscreen] .sine-web-panels-nav");
   assert.match(fullscreen, /display:\s*none/);
 });
+
+// --------------------------------------------------------------------------
+// Add / Edit popup. Tom's #3: Add is URL-only with the button on the right,
+// the name lives in Edit, and the popup is opaque.
+// --------------------------------------------------------------------------
+
+test("every popup of ours is opaque", () => {
+  // Sine loads the sheet at user level, so beating Zen's translucent
+  // --panel-background-color on the arrow panel takes !important.
+  const editor = rule("#sine-web-panels-editor");
+  assert.match(editor, /--panel-background-color:\s*var\(--sine-web-panels-opaque-surface\)\s*!important/);
+  // The transparent shadow ring toolkit keeps around an arrow panel is what
+  // let the page show around the fields; the host is painted too, so the
+  // popup is opaque whether or not ::part(content) matches.
+  assert.match(editor, /--panel-box-shadow-margin:\s*0px\s*!important/);
+  assert.match(editor, /\n  background:\s*var\(--sine-web-panels-opaque-surface\)\s*!important/);
+  assert.match(editor, /border:\s*1px solid/);
+  const content = rule("#sine-web-panels-editor::part(content)");
+  assert.match(content, /background:\s*var\(--sine-web-panels-opaque-surface\)\s*!important/);
+  assert.match(content, /backdrop-filter:\s*none/);
+
+  for (const selector of ["#sine-web-panels-menu", "#sine-web-panels-finder"]) {
+    const popup = rule(selector);
+    assert.match(popup, /background:\s*var\(--sine-web-panels-opaque-surface\)/, selector);
+    assert.doesNotMatch(popup, /backdrop-filter:\s*blur/, `${selector} has no blur`);
+  }
+
+  const token = css.match(/--sine-web-panels-opaque-surface:\s*var\(\s*--zen-dialog-background,\s*light-dark\(([^)]*)\)/);
+  assert.ok(token, "the surface follows Zen's dialog colour with a solid fallback");
+  assert.doesNotMatch(token[1], /rgba|transparent/, "the fallback is solid");
+});
+
+test("the popup surface is defined where the Add/Edit panel can see it", () => {
+  // The panel hangs off mainPopupSet, outside the rail, so a token declared
+  // on #sine-web-panels-root is invalid there and the background paints
+  // transparent — which is exactly how the page came to show through the
+  // fields.
+  assert.match(rule(":root"), /--sine-web-panels-opaque-surface:/);
+  const editor = rule("#sine-web-panels-editor");
+  for (const token of editor.matchAll(/var\(--sine-web-panels-([a-z-]+)/g)) {
+    assert.ok(
+      ["opaque-surface", "panel-color"].includes(token[1]),
+      `the editor uses rail-scoped token --sine-web-panels-${token[1]}`
+    );
+  }
+});
+
+test("the name field takes no room when it is not shown", () => {
+  assert.match(rule("#sine-web-panels-name-input[hidden]"), /display:\s*none/);
+  assert.match(rule("#sine-web-panels-editor-submit"), /justify-self:\s*end/, "Add sits on the right");
+});
+
+test("in Edit the URL and the name are the same width", () => {
+  const span = rule('#sine-web-panels-editor[mode="edit"] #sine-web-panels-url-input,\n#sine-web-panels-name-input');
+  assert.match(span, /grid-column:\s*1 \/ -1/);
+  assert.match(rule("#sine-web-panels-editor-submit"), /grid-column:\s*2/, "Save drops to its own row");
+});

--- a/scripts/tests/helpers/chrome-window.mjs
+++ b/scripts/tests/helpers/chrome-window.mjs
@@ -236,6 +236,10 @@ export class FakeElement {
     return found;
   }
 
+  focus() {}
+  select() {}
+  blur() {}
+
   getBoundingClientRect() {
     return { ...this.rect, right: this.rect.left + this.rect.width, bottom: this.rect.top + this.rect.height };
   }
@@ -491,6 +495,9 @@ export function createChromeWindow({ prefs = {}, viewportWidth = 1600 } = {}) {
   tabpanels.id = "tabbrowser-tabpanels";
   appContent.append(tabpanels);
   window.gBrowser.tabpanels = tabpanels;
+
+  // CSS.escape is a browser global the controller uses to build selectors.
+  globalThis.CSS = { escape: value => String(value).replace(/([^\w-])/g, "\\$1") };
 
   globalThis.Services = {
     appinfo: { OS: "Linux" },

--- a/scripts/tests/helpers/chrome-window.mjs
+++ b/scripts/tests/helpers/chrome-window.mjs
@@ -111,10 +111,19 @@ export class FakeElement {
   }
 
   setAttribute(name, value) {
+    // class= and classList are one thing in a browser; the controller sets
+    // the attribute and the selectors read the list.
+    if (name === "class") {
+      this.classList.value = String(value);
+      return;
+    }
     this.attributes.set(name, String(value));
   }
 
   getAttribute(name) {
+    if (name === "class") {
+      return this.classList.value || null;
+    }
     return this.attributes.has(name) ? this.attributes.get(name) : null;
   }
 
@@ -498,6 +507,7 @@ export function createChromeWindow({ prefs = {}, viewportWidth = 1600 } = {}) {
       },
     },
     scriptSecurityManager: { getSystemPrincipal: () => "system-principal" },
+    io: { newURI: spec => ({ spec }) },
   };
 
   return {

--- a/scripts/tests/helpers/chrome-window.mjs
+++ b/scripts/tests/helpers/chrome-window.mjs
@@ -61,6 +61,10 @@ class FakeStyle {
   }
 }
 
+function kebab(name) {
+  return String(name).replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
+}
+
 export class FakeElement {
   constructor(tagName = "div", ownerDocument = null) {
     this.tagName = tagName;
@@ -76,6 +80,18 @@ export class FakeElement {
     this.disabled = false;
     this.rect = { top: 0, left: 0, width: 0, height: 0 };
     this._key = `el-${nextId++}`;
+    // dataset.itemId <-> data-item-id, so attribute selectors see it.
+    this.dataset = new Proxy(
+      {},
+      {
+        get: (_, key) => this.attributes.get(`data-${kebab(key)}`),
+        set: (_, key, value) => {
+          this.attributes.set(`data-${kebab(key)}`, String(value));
+          return true;
+        },
+        deleteProperty: (_, key) => this.attributes.delete(`data-${kebab(key)}`),
+      }
+    );
   }
 
   get id() {
@@ -408,12 +424,43 @@ export function createChromeWindow({ prefs = {}, viewportWidth = 1600 } = {}) {
     },
     gBrowser: {
       tabs: [],
-      visibleTabs: [],
-      selectedTab: null,
+      // A getter, like the browser's: a hidden tab must drop out of it, or the
+      // controller's "find me an ordinary tab" never sees the truth.
+      get visibleTabs() {
+        return this.tabs.filter(tab => !tab.hidden);
+      },
+      _selectedTab: null,
+      get selectedTab() {
+        return this._selectedTab;
+      },
+      // Assigning fires TabSelect synchronously, as the browser does. A plain
+      // property here swallowed the event, and that hid a guard which undid
+      // every panel the moment it opened.
+      set selectedTab(tab) {
+        if (tab === this._selectedTab) return;
+        this._selectedTab = tab;
+        this.tabContainer.dispatch("TabSelect", { target: tab });
+      },
       tabContainer: new FakeElement("tabs", document),
+      tabpanels: null,
       addTrustedTab(url) {
+        return this._addTab(url);
+      },
+      // Builds the slice of Zen's tab deck that #openSurface anchors to:
+      // .browserSidebarContainer > .browserContainer > browser.
+      _addTab(url = "about:blank") {
         const tab = new FakeElement("tab", document);
-        tab.linkedBrowser = new FakeElement("browser", document);
+        const container = new FakeElement("vbox", document);
+        container.classList.add("browserSidebarContainer");
+        const frame = new FakeElement("vbox", document);
+        frame.classList.add("browserContainer");
+        const linkedBrowser = new FakeElement("browser", document);
+        linkedBrowser.currentURI = { spec: url };
+        frame.append(linkedBrowser);
+        container.append(frame);
+        this.tabpanels.append(container);
+        tab.linkedBrowser = linkedBrowser;
+        tab.linkedPanel = container;
         this.tabs.push(tab);
         return tab;
       },
@@ -430,6 +477,11 @@ export function createChromeWindow({ prefs = {}, viewportWidth = 1600 } = {}) {
   };
 
   document.defaultView = window;
+
+  const tabpanels = new FakeElement("tabpanels", document);
+  tabpanels.id = "tabbrowser-tabpanels";
+  appContent.append(tabpanels);
+  window.gBrowser.tabpanels = tabpanels;
 
   globalThis.Services = {
     appinfo: { OS: "Linux" },
@@ -454,6 +506,20 @@ export function createChromeWindow({ prefs = {}, viewportWidth = 1600 } = {}) {
     browser,
     appContent,
     prefs: globalThis.Services.prefs,
+
+    /** A tab in the strip, with the deck DOM the controller anchors panels to. */
+    addTab({ url = "about:blank", panelId = null, hidden = false, select = false } = {}) {
+      const tab = window.gBrowser._addTab(url);
+      tab.hidden = hidden;
+      if (panelId) {
+        tab.setAttribute("sine-web-panel-tab", "true");
+        tab.setAttribute("sine-web-panel-id", panelId);
+      }
+      if (select) {
+        window.gBrowser.selectedTab = tab;
+      }
+      return tab;
+    },
 
     /** Runs every timer due within `ms`, so peek timing is asserted not waited on. */
     advance(ms) {

--- a/scripts/tests/helpers/chrome-window.mjs
+++ b/scripts/tests/helpers/chrome-window.mjs
@@ -1,0 +1,489 @@
+/**
+ * A chrome window small enough to read and complete enough to mount the panel
+ * controller against.
+ *
+ * The point is to test behaviour, not text. Asserting that the source contains
+ * `browser.reload();` proves the string is there and nothing else: it passes
+ * when the behaviour is broken and fails when the code is merely renamed. So
+ * this fakes the parts of the browser the controller actually touches — the
+ * DOM, prefs, observers, gBrowser and the clock — and the tests then drive the
+ * real class through them.
+ *
+ * It is deliberately not a DOM implementation. Selector support covers the
+ * shapes the controller uses (`#id`, `.class`, `tag`, and combinations),
+ * matching the last compound of a descendant selector, which is enough because
+ * the controller never relies on ancestry to find anything.
+ */
+
+let nextId = 0;
+
+class FakeClassList {
+  #classes = new Set();
+
+  add(...names) {
+    for (const name of names) this.#classes.add(name);
+  }
+
+  remove(...names) {
+    for (const name of names) this.#classes.delete(name);
+  }
+
+  contains(name) {
+    return this.#classes.has(name);
+  }
+
+  get value() {
+    return [...this.#classes].join(" ");
+  }
+
+  set value(text) {
+    this.#classes = new Set(String(text ?? "").split(/\s+/).filter(Boolean));
+  }
+}
+
+class FakeStyle {
+  #properties = new Map();
+
+  setProperty(name, value) {
+    this.#properties.set(name, String(value));
+  }
+
+  removeProperty(name) {
+    this.#properties.delete(name);
+  }
+
+  getPropertyValue(name) {
+    return this.#properties.get(name) ?? "";
+  }
+
+  has(name) {
+    return this.#properties.has(name);
+  }
+}
+
+export class FakeElement {
+  constructor(tagName = "div", ownerDocument = null) {
+    this.tagName = tagName;
+    this.ownerDocument = ownerDocument;
+    this.children = [];
+    this.parentNode = null;
+    this.classList = new FakeClassList();
+    this.style = new FakeStyle();
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this.textContent = "";
+    this.hidden = false;
+    this.disabled = false;
+    this.rect = { top: 0, left: 0, width: 0, height: 0 };
+    this._key = `el-${nextId++}`;
+  }
+
+  get id() {
+    return this.attributes.get("id") ?? "";
+  }
+
+  set id(value) {
+    this.attributes.set("id", String(value));
+  }
+
+  get className() {
+    return this.classList.value;
+  }
+
+  set className(value) {
+    this.classList.value = value;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
+  hasAttribute(name) {
+    return this.attributes.has(name);
+  }
+
+  toggleAttribute(name, force) {
+    const next = force === undefined ? !this.attributes.has(name) : Boolean(force);
+    if (next) {
+      this.attributes.set(name, "true");
+    } else {
+      this.attributes.delete(name);
+    }
+    return next;
+  }
+
+  append(...nodes) {
+    for (const node of nodes) {
+      if (!node) continue;
+      node.parentNode?.removeChild?.(node);
+      node.parentNode = this;
+      this.children.push(node);
+    }
+  }
+
+  appendChild(node) {
+    this.append(node);
+    return node;
+  }
+
+  insertBefore(node, reference) {
+    const index = reference ? this.children.indexOf(reference) : -1;
+    node.parentNode = this;
+    if (index === -1) {
+      this.children.push(node);
+    } else {
+      this.children.splice(index, 0, node);
+    }
+    return node;
+  }
+
+  removeChild(node) {
+    const index = this.children.indexOf(node);
+    if (index !== -1) {
+      this.children.splice(index, 1);
+      node.parentNode = null;
+    }
+    return node;
+  }
+
+  replaceChildren(...nodes) {
+    for (const child of this.children) child.parentNode = null;
+    this.children = [];
+    this.append(...nodes);
+  }
+
+  remove() {
+    this.parentNode?.removeChild(this);
+  }
+
+  addEventListener(type, handler) {
+    if (!this.listeners.has(type)) this.listeners.set(type, []);
+    this.listeners.get(type).push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    const handlers = this.listeners.get(type) ?? [];
+    const index = handlers.indexOf(handler);
+    if (index !== -1) handlers.splice(index, 1);
+  }
+
+  dispatch(type, event = {}) {
+    for (const handler of [...(this.listeners.get(type) ?? [])]) {
+      handler({ target: this, preventDefault() {}, stopPropagation() {}, ...event });
+    }
+  }
+
+  matches(selector) {
+    return matchesCompound(this, lastCompound(selector));
+  }
+
+  closest(selector) {
+    let node = this;
+    while (node) {
+      if (node.matches?.(selector)) return node;
+      node = node.parentNode;
+    }
+    return null;
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector) {
+    const compound = lastCompound(selector);
+    const found = [];
+    const walk = node => {
+      for (const child of node.children) {
+        if (matchesCompound(child, compound)) found.push(child);
+        walk(child);
+      }
+    };
+    walk(this);
+    return found;
+  }
+
+  getBoundingClientRect() {
+    return { ...this.rect, right: this.rect.left + this.rect.width, bottom: this.rect.top + this.rect.height };
+  }
+}
+
+function lastCompound(selector) {
+  const parts = String(selector).trim().split(/\s*[>\s]\s*/).filter(Boolean);
+  return parts[parts.length - 1] ?? "";
+}
+
+function matchesCompound(element, compound) {
+  if (!compound) return false;
+  const id = /#([A-Za-z0-9_-]+)/.exec(compound)?.[1];
+  if (id && element.id !== id) return false;
+
+  for (const [, cls] of compound.matchAll(/\.([A-Za-z0-9_-]+)/g)) {
+    if (!element.classList.contains(cls)) return false;
+  }
+
+  const attribute = /\[([A-Za-z0-9_-]+)(?:="([^"]*)")?\]/.exec(compound);
+  if (attribute) {
+    const [, name, value] = attribute;
+    if (!element.hasAttribute(name)) return false;
+    if (value !== undefined && element.getAttribute(name) !== value) return false;
+  }
+
+  const tag = /^[A-Za-z][A-Za-z0-9-]*/.exec(compound)?.[0];
+  if (tag && element.tagName !== tag) return false;
+
+  return true;
+}
+
+class FakeDocument {
+  constructor() {
+    this.documentElement = new FakeElement("html", this);
+    this.body = new FakeElement("body", this);
+    this.documentElement.append(this.body);
+    this.listeners = new Map();
+    this.fullscreenElement = null;
+    this.defaultView = null;
+  }
+
+  createElement(tagName) {
+    return new FakeElement(tagName, this);
+  }
+
+  createXULElement(tagName) {
+    return new FakeElement(tagName, this);
+  }
+
+  getElementById(id) {
+    return this.documentElement.querySelector(`#${id}`);
+  }
+
+  querySelector(selector) {
+    return this.documentElement.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.documentElement.querySelectorAll(selector);
+  }
+
+  addEventListener(type, handler) {
+    if (!this.listeners.has(type)) this.listeners.set(type, []);
+    this.listeners.get(type).push(handler);
+  }
+
+  removeEventListener() {}
+
+  dispatch(type, event = {}) {
+    for (const handler of [...(this.listeners.get(type) ?? [])]) {
+      handler({ preventDefault() {}, stopPropagation() {}, ...event });
+    }
+  }
+}
+
+/** A pref branch with observers, since the controller reacts to pref changes. */
+export function createPrefs(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  const observers = new Map();
+
+  const notify = name => {
+    for (const observer of [...(observers.get(name) ?? [])]) {
+      observer.observe(null, "nsPref:changed", name);
+    }
+  };
+
+  return {
+    values,
+    getBoolPref: (name, fallback = false) => values.get(name) ?? fallback,
+    setBoolPref: (name, value) => {
+      values.set(name, Boolean(value));
+      notify(name);
+    },
+    getStringPref: (name, fallback = "") => values.get(name) ?? fallback,
+    setStringPref: (name, value) => {
+      values.set(name, String(value));
+      notify(name);
+    },
+    getCharPref: (name, fallback = "") => values.get(name) ?? fallback,
+    setCharPref: (name, value) => {
+      values.set(name, String(value));
+      notify(name);
+    },
+    getPrefType: name => (values.has(name) ? 32 : 0),
+    clearUserPref: name => {
+      values.delete(name);
+      notify(name);
+    },
+    addObserver: (name, observer) => {
+      if (!observers.has(name)) observers.set(name, []);
+      observers.get(name).push(observer);
+    },
+    removeObserver: (name, observer) => {
+      const list = observers.get(name) ?? [];
+      const index = list.indexOf(observer);
+      if (index !== -1) list.splice(index, 1);
+    },
+  };
+}
+
+/**
+ * Builds the window, installs globalThis.Services, and returns handles for
+ * driving it: the clock has to be pumped by hand so timed behaviour (the peek
+ * timer) is asserted rather than waited on.
+ */
+export function createChromeWindow({ prefs = {}, viewportWidth = 1600 } = {}) {
+  const document = new FakeDocument();
+  const timers = new Map();
+  let nextTimer = 1;
+  let now = 0;
+
+  const browser = new FakeElement("box", document);
+  browser.id = "browser";
+  document.body.append(browser);
+
+  const appContent = new FakeElement("box", document);
+  appContent.id = "zen-appcontent-wrapper";
+  appContent.rect = { top: 0, left: 0, width: viewportWidth, height: 900 };
+  browser.append(appContent);
+
+  for (const id of ["mainPopupSet", "tabContextMenu", "context_closeTab"]) {
+    const element = new FakeElement("box", document);
+    element.id = id;
+    document.body.append(element);
+  }
+
+  const observerTopics = new Map();
+  const mutationObservers = [];
+
+  const window = {
+    document,
+    innerWidth: viewportWidth,
+    innerHeight: 900,
+    fullScreen: false,
+    performance: { now: () => now },
+    getComputedStyle: element => ({
+      getPropertyValue: name => element.style.getPropertyValue(name),
+      color: "rgb(0, 0, 0)",
+    }),
+    setTimeout: (fn, delay = 0) => {
+      const id = nextTimer++;
+      timers.set(id, { fn, at: now + delay });
+      return id;
+    },
+    clearTimeout: id => timers.delete(id),
+    requestAnimationFrame: fn => {
+      fn();
+      return 0;
+    },
+    addEventListener: (type, handler) => document.addEventListener(type, handler),
+    removeEventListener: () => {},
+    MutationObserver: class {
+      constructor(callback) {
+        this.callback = callback;
+        mutationObservers.push(this);
+      }
+      observe(target, options) {
+        this.target = target;
+        this.options = options;
+      }
+      disconnect() {
+        const index = mutationObservers.indexOf(this);
+        if (index !== -1) mutationObservers.splice(index, 1);
+      }
+    },
+    SessionStore: {
+      values: new Map(),
+      setCustomTabValue(tab, key, value) {
+        this.values.set(tab, { ...(this.values.get(tab) ?? {}), [key]: value });
+      },
+      getCustomTabValue(tab, key) {
+        return this.values.get(tab)?.[key] ?? "";
+      },
+    },
+    gBrowser: {
+      tabs: [],
+      visibleTabs: [],
+      selectedTab: null,
+      tabContainer: new FakeElement("tabs", document),
+      addTrustedTab(url) {
+        const tab = new FakeElement("tab", document);
+        tab.linkedBrowser = new FakeElement("browser", document);
+        this.tabs.push(tab);
+        return tab;
+      },
+      hideTab() {},
+      removeTab(tab) {
+        tab.closing = true;
+        const index = this.tabs.indexOf(tab);
+        if (index !== -1) this.tabs.splice(index, 1);
+      },
+      addTabsProgressListener() {},
+      removeTabsProgressListener() {},
+      getTabForBrowser: () => null,
+    },
+  };
+
+  document.defaultView = window;
+
+  globalThis.Services = {
+    appinfo: { OS: "Linux" },
+    prefs: createPrefs(prefs),
+    obs: {
+      addObserver: (observer, topic) => {
+        if (!observerTopics.has(topic)) observerTopics.set(topic, []);
+        observerTopics.get(topic).push(observer);
+      },
+      removeObserver: (observer, topic) => {
+        const list = observerTopics.get(topic) ?? [];
+        const index = list.indexOf(observer);
+        if (index !== -1) list.splice(index, 1);
+      },
+    },
+    scriptSecurityManager: { getSystemPrincipal: () => "system-principal" },
+  };
+
+  return {
+    window,
+    document,
+    browser,
+    appContent,
+    prefs: globalThis.Services.prefs,
+
+    /** Runs every timer due within `ms`, so peek timing is asserted not waited on. */
+    advance(ms) {
+      now += ms;
+      for (const [id, timer] of [...timers]) {
+        if (timer.at <= now) {
+          timers.delete(id);
+          timer.fn();
+        }
+      }
+    },
+
+    /** Flips an attribute on the chrome root and runs the observers watching it. */
+    setRootAttribute(name, value) {
+      if (value === null) {
+        document.documentElement.removeAttribute(name);
+      } else {
+        document.documentElement.setAttribute(name, value);
+      }
+      for (const observer of mutationObservers) {
+        if (observer.options?.attributeFilter?.includes(name)) {
+          observer.callback([{ attributeName: name }]);
+        }
+      }
+    },
+
+    notify(topic) {
+      for (const observer of [...(observerTopics.get(topic) ?? [])]) {
+        observer.observe(null, topic, null);
+      }
+    },
+  };
+}

--- a/scripts/tests/runtime.test.mjs
+++ b/scripts/tests/runtime.test.mjs
@@ -49,13 +49,25 @@ function createWindow() {
   const hiddenTabs = [];
   const removedTabs = [];
   const calls = [];
+  // Keyed by tab, the way SessionStore's custom values are.
+  const sessionValues = new Map();
 
   return {
     calls,
     tabs,
     hiddenTabs,
     removedTabs,
+    sessionValues,
+    SessionStore: {
+      setCustomTabValue(tab, key, value) {
+        sessionValues.set(tab, { ...(sessionValues.get(tab) ?? {}), [key]: value });
+      },
+      getCustomTabValue(tab, key) {
+        return sessionValues.get(tab)?.[key] ?? "";
+      },
+    },
     gBrowser: {
+      tabs,
       addTrustedTab(url, options) {
         calls.push({ name: "addTrustedTab", url, options });
         const tab = new FakeTab(url);
@@ -68,9 +80,24 @@ function createWindow() {
       removeTab(tab, options) {
         tab.closing = true;
         removedTabs.push({ tab, options });
+        const index = tabs.indexOf(tab);
+        if (index !== -1) {
+          tabs.splice(index, 1);
+        }
       },
     },
   };
+}
+
+// What a restart leaves behind: the tab and its session value survive, every
+// attribute we stamped on the element does not.
+function restartWindow(windowRef) {
+  for (const tab of windowRef.tabs) {
+    tab.attributes.clear();
+    tab.owner = undefined;
+  }
+  windowRef.hiddenTabs.length = 0;
+  windowRef.calls.length = 0;
 }
 
 test("ensurePanelTab creates a trusted hidden tab with panel metadata", () => {
@@ -134,6 +161,7 @@ test("unload removes the managed tab and clears runtime state", () => {
   assert.deepEqual(windowRef.removedTabs[0].options, {
     animate: false,
     skipPermitUnload: true,
+    skipSessionStore: true,
   });
   assert.equal(runtime.get("panel-1"), null);
 });
@@ -160,4 +188,107 @@ test("noteTabClosed clears the stored tab without deleting the panel record", ()
   runtime.noteTabClosed("panel-1");
 
   assert.equal(runtime.get("panel-1").tab, undefined);
+});
+
+// --------------------------------------------------------------------------
+// Session restore. The bug these pin: panels came back as ordinary tabs after
+// a restart, and opening the panel then made a second tab beside the stranded
+// one. Attributes do not survive a restart; a session value does.
+// --------------------------------------------------------------------------
+
+test("a panel tab is marked so it can be recognised after a restart", () => {
+  const windowRef = createWindow();
+  const runtime = new WebPanelsRuntime(windowRef);
+
+  const tab = runtime.ensurePanelTab({ id: "panel-1", url: "https://calendar.example/" });
+
+  assert.equal(
+    windowRef.SessionStore.getCustomTabValue(tab, "sineWebPanelBacking"),
+    "panel-1"
+  );
+});
+
+test("a restored panel tab is reclaimed rather than left in the tab strip", () => {
+  const windowRef = createWindow();
+  const item = { id: "panel-1", url: "https://calendar.example/" };
+  const tab = new WebPanelsRuntime(windowRef).ensurePanelTab(item);
+  restartWindow(windowRef);
+
+  // A fresh runtime, the way a restarted window gets one.
+  const runtime = new WebPanelsRuntime(windowRef);
+  const { adopted, swept } = runtime.adoptRestoredTabs([item]);
+
+  assert.deepEqual(adopted, ["panel-1"]);
+  assert.deepEqual(swept, []);
+  assert.equal(windowRef.removedTabs.length, 0, "adoption keeps the tab");
+  assert.equal(tab.getAttribute("sine-web-panel-tab"), "true", "marks reapplied");
+  assert.equal(windowRef.hiddenTabs.at(-1)?.tab, tab, "hidden again");
+  assert.equal(runtime.get("panel-1")?.tab, tab, "registered as the backing");
+});
+
+test("after adoption the panel opens the tab it already had", () => {
+  const windowRef = createWindow();
+  const item = { id: "panel-1", url: "https://calendar.example/" };
+  const original = new WebPanelsRuntime(windowRef).ensurePanelTab(item);
+  restartWindow(windowRef);
+
+  const runtime = new WebPanelsRuntime(windowRef);
+  runtime.adoptRestoredTabs([item]);
+  const reopened = runtime.ensurePanelTab(item);
+
+  assert.equal(reopened, original, "no second tab");
+  assert.equal(windowRef.calls.length, 0, "nothing was created");
+  assert.equal(windowRef.tabs.length, 1);
+});
+
+test("a marked tab whose panel is gone from the rail is swept", () => {
+  const windowRef = createWindow();
+  const deleted = { id: "panel-deleted", url: "https://gone.example/" };
+  const tab = new WebPanelsRuntime(windowRef).ensurePanelTab(deleted);
+  restartWindow(windowRef);
+
+  const runtime = new WebPanelsRuntime(windowRef);
+  const { adopted, swept } = runtime.adoptRestoredTabs([]);
+
+  assert.deepEqual(adopted, []);
+  assert.deepEqual(swept, ["panel-deleted"]);
+  assert.equal(windowRef.removedTabs[0]?.tab, tab);
+  assert.equal(windowRef.removedTabs[0]?.options.skipSessionStore, true);
+});
+
+test("ordinary tabs are never touched", () => {
+  const windowRef = createWindow();
+  const ordinary = new FakeTab("https://news.example/");
+  windowRef.tabs.push(ordinary);
+
+  const runtime = new WebPanelsRuntime(windowRef);
+  const { adopted, swept } = runtime.adoptRestoredTabs([
+    { id: "panel-1", url: "https://calendar.example/" },
+  ]);
+
+  assert.deepEqual(adopted, []);
+  assert.deepEqual(swept, []);
+  assert.equal(windowRef.removedTabs.length, 0);
+  assert.equal(windowRef.hiddenTabs.length, 0);
+  assert.equal(windowRef.tabs.length, 1);
+});
+
+test("a duplicate backing is swept rather than replacing the live tab", () => {
+  const windowRef = createWindow();
+  const item = { id: "panel-1", url: "https://calendar.example/" };
+  const runtime = new WebPanelsRuntime(windowRef);
+  const live = runtime.ensurePanelTab(item);
+
+  // A second tab claiming the same panel — a restored one the runtime never
+  // adopted, next to a tab it already opened this session.
+  const stale = new FakeTab("https://calendar.example/");
+  windowRef.SessionStore.setCustomTabValue(stale, "sineWebPanelBacking", "panel-1");
+  windowRef.tabs.push(stale);
+
+  const { adopted, swept } = runtime.adoptRestoredTabs([item]);
+
+  assert.deepEqual(swept, ["panel-1"]);
+  assert.deepEqual(adopted, ["panel-1"], "the live one is still claimed");
+  assert.equal(windowRef.removedTabs[0]?.tab, stale);
+  assert.equal(runtime.get("panel-1")?.tab, live, "the live tab is kept");
 });

--- a/scripts/tests/runtime.test.mjs
+++ b/scripts/tests/runtime.test.mjs
@@ -68,6 +68,7 @@ function createWindow() {
     },
     gBrowser: {
       tabs,
+      selectedTab: null,
       addTrustedTab(url, options) {
         calls.push({ name: "addTrustedTab", url, options });
         const tab = new FakeTab(url);
@@ -75,6 +76,12 @@ function createWindow() {
         return tab;
       },
       hideTab(tab, reason) {
+        // Zen's hideTab returns early on the selected tab, silently. Model it,
+        // or a test goes green while the browser does nothing at all.
+        if (tab === this.selectedTab || tab.closing || tab.hidden) {
+          return;
+        }
+        tab.hidden = true;
         hiddenTabs.push({ tab, reason });
       },
       removeTab(tab, options) {
@@ -95,6 +102,7 @@ function restartWindow(windowRef) {
   for (const tab of windowRef.tabs) {
     tab.attributes.clear();
     tab.owner = undefined;
+    tab.hidden = false;
   }
   windowRef.hiddenTabs.length = 0;
   windowRef.calls.length = 0;
@@ -291,4 +299,47 @@ test("a duplicate backing is swept rather than replacing the live tab", () => {
   assert.deepEqual(adopted, ["panel-1"], "the live one is still claimed");
   assert.equal(windowRef.removedTabs[0]?.tab, stale);
   assert.equal(runtime.get("panel-1")?.tab, live, "the live tab is kept");
+});
+
+// --------------------------------------------------------------------------
+// The selected tab. Opening a panel selects its tab, so that is the state the
+// session is saved in — and Zen's hideTab returns early on the selected tab,
+// silently. Adopting one without moving the selection first leaves the window
+// displaying a panel backing as an ordinary tab, with every panel then unable
+// to open because there is no visible tab to anchor the overlay to.
+// --------------------------------------------------------------------------
+
+test("a restored panel tab that holds the selection gives it up before hiding", () => {
+  const windowRef = createWindow();
+  const ordinary = new FakeTab("https://news.example/");
+  windowRef.tabs.push(ordinary);
+
+  const item = { id: "panel-1", url: "https://mail.example/" };
+  const panelTab = new WebPanelsRuntime(windowRef).ensurePanelTab(item);
+  restartWindow(windowRef);
+  // Session restore brings it back selected, because that is how it was saved.
+  windowRef.gBrowser.selectedTab = panelTab;
+
+  const runtime = new WebPanelsRuntime(windowRef);
+  const { adopted } = runtime.adoptRestoredTabs([item]);
+
+  assert.deepEqual(adopted, ["panel-1"]);
+  assert.equal(windowRef.gBrowser.selectedTab, ordinary, "selection handed over");
+  assert.equal(panelTab.hidden, true, "and the hide actually took");
+});
+
+test("the last tab in a window is left visible rather than stranding it", () => {
+  const windowRef = createWindow();
+  const item = { id: "panel-1", url: "https://mail.example/" };
+  const panelTab = new WebPanelsRuntime(windowRef).ensurePanelTab(item);
+  restartWindow(windowRef);
+  windowRef.gBrowser.selectedTab = panelTab;
+
+  const runtime = new WebPanelsRuntime(windowRef);
+  const { adopted, swept } = runtime.adoptRestoredTabs([item]);
+
+  assert.deepEqual(adopted, [], "not claimed");
+  assert.deepEqual(swept, [], "and certainly not deleted");
+  assert.equal(panelTab.hidden, false, "a window must not sit on a hidden tab");
+  assert.equal(windowRef.gBrowser.selectedTab, panelTab);
 });

--- a/scripts/tests/store.test.mjs
+++ b/scripts/tests/store.test.mjs
@@ -2,8 +2,14 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 const {
+  calculateWebPanelViewportGeometry,
+  clampWebPanelWidth,
   formatWebPanelUnreadCount,
+  MIN_PANEL_WIDTH,
   normalizeWebPanelUrl,
+  PANEL_VIEWPORT_INSET,
+  PANEL_VIEWPORT_MAX_WIDTH_RATIO,
+  panelMaxWidthFromViewport,
   parseWebPanelUnreadCount,
   titleFromUrl,
 } = await import("../web-panels-store.uc.mjs");
@@ -29,4 +35,118 @@ test("unread helpers parse and format title-prefixed counts", () => {
   assert.equal(formatWebPanelUnreadCount(0), "");
   assert.equal(formatWebPanelUnreadCount(12), "12");
   assert.equal(formatWebPanelUnreadCount(120), "99+");
+});
+
+// --------------------------------------------------------------------------
+// Panel geometry. The bug these pin: the maximum width used to come from
+// window.innerWidth, so Zen's left sidebar was never subtracted and the panel
+// could grow over it — one profile had the width stored at 2009px.
+// --------------------------------------------------------------------------
+
+const WINDOW = { top: 0, left: 0, width: 1920, height: 1080 };
+
+test("viewport geometry measures the page area, not the whole window", () => {
+  // Zen's sidebar takes the first 320px, so only 1600 are the page's.
+  const rect = { top: 40, left: 320, width: 1600, height: 1000 };
+  const geometry = calculateWebPanelViewportGeometry(rect, WINDOW);
+
+  assert.equal(geometry.maxWidth, Math.floor(1600 * PANEL_VIEWPORT_MAX_WIDTH_RATIO));
+  assert.ok(geometry.maxWidth < WINDOW.width, "must not span the whole window");
+  assert.equal(geometry.top, 40 + PANEL_VIEWPORT_INSET);
+  assert.equal(geometry.height, 1000 - PANEL_VIEWPORT_INSET * 2);
+});
+
+test("viewport geometry clips the rect to the window it sits in", () => {
+  // A rect reaching past the window edge must not widen the maximum.
+  const rect = { top: 0, left: 1000, width: 4000, height: 1080 };
+  const geometry = calculateWebPanelViewportGeometry(rect, WINDOW);
+
+  assert.equal(geometry.maxWidth, Math.floor(920 * PANEL_VIEWPORT_MAX_WIDTH_RATIO));
+});
+
+test("viewport geometry falls back to the window when the rect is unusable", () => {
+  const expected = Math.floor(WINDOW.width * PANEL_VIEWPORT_MAX_WIDTH_RATIO);
+
+  assert.equal(calculateWebPanelViewportGeometry(null, WINDOW).maxWidth, expected);
+  assert.equal(calculateWebPanelViewportGeometry({}, WINDOW).maxWidth, expected);
+  assert.equal(
+    calculateWebPanelViewportGeometry({ width: Number.NaN, height: 0 }, WINDOW).maxWidth,
+    expected
+  );
+});
+
+test("viewport geometry never returns a negative or zero maximum", () => {
+  const geometry = calculateWebPanelViewportGeometry(
+    { top: 0, left: 0, width: 0, height: 0 },
+    { top: 0, left: 0, width: 0, height: 0 }
+  );
+
+  assert.ok(geometry.maxWidth >= 1);
+  assert.ok(geometry.height >= 0);
+});
+
+test("clampWebPanelWidth keeps a width inside the measured maximum", () => {
+  assert.equal(clampWebPanelWidth(600, 1520), 600);
+  assert.equal(clampWebPanelWidth(2009, 1520), 1520, "the 2009px regression");
+  assert.equal(clampWebPanelWidth(100, 1520), MIN_PANEL_WIDTH);
+});
+
+test("clampWebPanelWidth lets the maximum win over the minimum", () => {
+  // A window narrower than MIN_PANEL_WIDTH: overflowing is worse than narrow.
+  assert.equal(clampWebPanelWidth(400, 200), 200);
+  assert.equal(clampWebPanelWidth(50, 200), 200);
+});
+
+test("clampWebPanelWidth survives nonsense input", () => {
+  assert.equal(clampWebPanelWidth(Number.NaN, 1520), MIN_PANEL_WIDTH);
+  assert.equal(clampWebPanelWidth(undefined, 1520), MIN_PANEL_WIDTH);
+  assert.equal(clampWebPanelWidth(600, 0), 1);
+  assert.equal(clampWebPanelWidth(600, Number.NaN), 1);
+  assert.equal(clampWebPanelWidth(600.6, 1520), 601, "rounds rather than truncating");
+});
+
+// --------------------------------------------------------------------------
+// Trusting a bad measurement is worse than not clamping. Both regressions
+// these pin were shipped: measuring an element that was not laid out fell back
+// to the whole window and put the panel over Zen's sidebar, and a maximum
+// under the minimum pinned every clamp to one value and froze the resizer.
+// --------------------------------------------------------------------------
+
+test("a rect that was never laid out yields no maximum, not the whole window", () => {
+  assert.equal(panelMaxWidthFromViewport(null, WINDOW), null);
+  assert.equal(panelMaxWidthFromViewport({}, WINDOW), null);
+  assert.equal(
+    panelMaxWidthFromViewport({ top: 0, left: 0, width: 0, height: 0 }, WINDOW),
+    null
+  );
+});
+
+test("a maximum below the minimum panel width is rejected as a bad measurement", () => {
+  // 100px of usable width is never a real window — it is the wrong element.
+  assert.equal(
+    panelMaxWidthFromViewport({ top: 0, left: 0, width: 100, height: 900 }, WINDOW),
+    null
+  );
+});
+
+test("a rejected measurement cannot freeze the resizer", () => {
+  // The symptom: with a maximum under the minimum, clamp returns the same
+  // value for every input, so dragging the edge changes nothing.
+  const frozen = [400, 600, 900].map(w => clampWebPanelWidth(w, 100));
+  assert.deepEqual(frozen, [100, 100, 100], "this is what must never be reached");
+
+  // Rejecting the measurement is what keeps the caller off that path.
+  assert.equal(
+    panelMaxWidthFromViewport({ top: 0, left: 0, width: 100, height: 900 }, WINDOW),
+    null
+  );
+});
+
+test("a good measurement still yields a maximum", () => {
+  const rect = { top: 40, left: 0, width: 1600, height: 1000 };
+
+  assert.equal(
+    panelMaxWidthFromViewport(rect, WINDOW),
+    Math.floor(1600 * PANEL_VIEWPORT_MAX_WIDTH_RATIO)
+  );
 });

--- a/scripts/tests/store.test.mjs
+++ b/scripts/tests/store.test.mjs
@@ -6,6 +6,7 @@ const {
   clampWebPanelWidth,
   formatWebPanelUnreadCount,
   MIN_PANEL_WIDTH,
+  normalizeResizerColor,
   normalizeWebPanelUrl,
   PANEL_VIEWPORT_INSET,
   PANEL_VIEWPORT_MAX_WIDTH_RATIO,
@@ -149,4 +150,58 @@ test("a good measurement still yields a maximum", () => {
     panelMaxWidthFromViewport(rect, WINDOW),
     Math.floor(1600 * PANEL_VIEWPORT_MAX_WIDTH_RATIO)
   );
+});
+
+// --------------------------------------------------------------------------
+// The resize handle colour is the only setting that becomes CSS, so it is
+// validated rather than trusted. Anything rejected becomes "", which is also
+// the default and the way back: empty lets the stylesheet's theme chain win.
+// --------------------------------------------------------------------------
+
+test("resizer colour accepts the notations a person would actually type", () => {
+  for (const value of [
+    "#abc",
+    "#abcd",
+    "#3b82f6",
+    "#3b82f680",
+    "rebeccapurple",
+    "AccentColor",
+    "rgb(59 130 246)",
+    "rgba(59, 130, 246, 0.5)",
+    "hsl(217 91% 60%)",
+    "oklch(0.7 0.2 250)",
+  ]) {
+    assert.equal(normalizeResizerColor(value), value, value);
+  }
+});
+
+test("resizer colour trims, and treats blank as the default", () => {
+  assert.equal(normalizeResizerColor("  #3b82f6  "), "#3b82f6");
+  assert.equal(normalizeResizerColor(""), "");
+  assert.equal(normalizeResizerColor("   "), "");
+  assert.equal(normalizeResizerColor(null), "");
+  assert.equal(normalizeResizerColor(undefined), "");
+});
+
+test("resizer colour refuses anything that could escape the declaration", () => {
+  for (const value of [
+    "red; background: url(http://example.com/x)",
+    "red}",
+    "}",
+    "url(http://example.com/x)",
+    "var(--something-else)",
+    "#12345",
+    "#gggggg",
+    "expression(alert(1))",
+    "rgb(0,0,0);--x:y",
+    'rgb(0,0,0)"',
+  ]) {
+    assert.equal(normalizeResizerColor(value), "", value);
+  }
+});
+
+test("a rejected colour is indistinguishable from unset, so the theme wins", () => {
+  // Both paths end at "", which is what makes the reset a real reset: the
+  // caller removes the custom property and the stylesheet chain takes over.
+  assert.equal(normalizeResizerColor("nonsense{}"), normalizeResizerColor(""));
 });

--- a/scripts/tests/store.test.mjs
+++ b/scripts/tests/store.test.mjs
@@ -13,6 +13,7 @@ const {
   panelMaxWidthFromViewport,
   parseWebPanelUnreadCount,
   titleFromUrl,
+  webPanelSideForSidebar,
 } = await import("../web-panels-store.uc.mjs");
 
 test("normalizeWebPanelUrl accepts only http and https URLs", () => {
@@ -204,4 +205,27 @@ test("a rejected colour is indistinguishable from unset, so the theme wins", () 
   // Both paths end at "", which is what makes the reset a real reset: the
   // caller removes the custom property and the stylesheet chain takes over.
   assert.equal(normalizeResizerColor("nonsense{}"), normalizeResizerColor(""));
+});
+
+// --------------------------------------------------------------------------
+// The rail takes the side Zen's sidebar is NOT on. The inversion reads
+// backwards at a glance, which is exactly why it is pinned.
+// --------------------------------------------------------------------------
+
+test("the rail sits opposite Zen's sidebar", () => {
+  assert.equal(webPanelSideForSidebar("true"), "left", "sidebar right, rail left");
+  assert.equal(webPanelSideForSidebar("false"), "right", "sidebar left, rail right");
+});
+
+test("no sidebar attribute means Zen's default, so the rail goes right", () => {
+  assert.equal(webPanelSideForSidebar(null), "right");
+  assert.equal(webPanelSideForSidebar(undefined), "right");
+  assert.equal(webPanelSideForSidebar(""), "right");
+});
+
+test("only the exact attribute value flips the rail", () => {
+  // Zen writes the string "true"; anything else is not a sidebar on the right.
+  for (const value of ["TRUE", "1", "yes", "right", true]) {
+    assert.equal(webPanelSideForSidebar(value), value === true ? "left" : "right", String(value));
+  }
 });

--- a/scripts/web-panels-runtime.uc.mjs
+++ b/scripts/web-panels-runtime.uc.mjs
@@ -81,8 +81,9 @@ export class WebPanelsRuntime {
         continue;
       }
 
-      this.#claimTab(tab, item, this.#panels.get(panelId)?.parentTab ?? null);
-      adopted.push(panelId);
+      if (this.#claimTab(tab, item, this.#panels.get(panelId)?.parentTab ?? null)) {
+        adopted.push(panelId);
+      }
     }
 
     return { adopted, swept };
@@ -126,6 +127,16 @@ export class WebPanelsRuntime {
   }
 
   #claimTab(tab, item, parentTab = null) {
+    // Opening a panel selects its tab, so that is the state the session is
+    // saved in and the state it is restored in. Zen's hideTab returns early on
+    // the selected tab — silently, no error — so hiding without checking
+    // leaves the window sitting on a panel backing displayed as an ordinary
+    // tab. From there nothing works: opening any panel needs a visible tab to
+    // anchor the overlay to, and the selected one is the panel itself.
+    if (!this.#releaseSelection(tab)) {
+      return false;
+    }
+
     tab.owner = null;
     tab.setAttribute(PANEL_TAB_ATTRIBUTE, "true");
     tab.setAttribute(PANEL_ID_ATTRIBUTE, item.id);
@@ -134,6 +145,32 @@ export class WebPanelsRuntime {
 
     this.#window.gBrowser.hideTab?.(tab, TAB_HIDE_OWNER);
     this.#panels.set(item.id, { item, parentTab, tab });
+    return true;
+  }
+
+  // Hands the selection to an ordinary tab if this one holds it. False when
+  // there is nothing to hand it to — the one case where hiding would strand
+  // the window on a tab it cannot show, so the caller leaves the tab alone
+  // instead.
+  #releaseSelection(tab) {
+    const gBrowser = this.#window?.gBrowser;
+    if (!gBrowser || gBrowser.selectedTab !== tab) {
+      return true;
+    }
+
+    const replacement = this.#allTabs().find(
+      candidate => candidate !== tab && !candidate.closing && !this.#backingPanelId(candidate)
+    );
+    if (!replacement) {
+      console.warn(
+        "[Web Panels] A panel tab holds the selection and there is no other tab " +
+          "to move it to, so it stays visible rather than stranding the window."
+      );
+      return false;
+    }
+
+    gBrowser.selectedTab = replacement;
+    return true;
   }
 
   #allTabs() {

--- a/scripts/web-panels-runtime.uc.mjs
+++ b/scripts/web-panels-runtime.uc.mjs
@@ -15,7 +15,7 @@ export class WebPanelsRuntime {
     return this.#panels.get(id)?.tab?.linkedBrowser ?? null;
   }
 
-  ensurePanelTab(item, parentTab = null) {
+  ensurePanelTab(item, parentTab = null, url = null) {
     const existing = this.#panels.get(item.id) ?? {};
     if (existing.tab && !existing.tab.closing) {
       existing.item = item;
@@ -25,7 +25,7 @@ export class WebPanelsRuntime {
       return existing.tab;
     }
 
-    const tab = this.#createPanelTab(item);
+    const tab = this.#createPanelTab(item, url ?? item.url);
     tab.owner = null;
     tab.setAttribute("sine-web-panel-tab", "true");
     tab.setAttribute("sine-web-panel-id", item.id);
@@ -76,7 +76,7 @@ export class WebPanelsRuntime {
     this.#window = null;
   }
 
-  #createPanelTab(item) {
+  #createPanelTab(item, url) {
     const options = {
       inBackground: true,
       skipAnimation: true,
@@ -85,10 +85,10 @@ export class WebPanelsRuntime {
     };
 
     if (typeof this.#window.gBrowser.addTrustedTab === "function") {
-      return this.#window.gBrowser.addTrustedTab(item.url, options);
+      return this.#window.gBrowser.addTrustedTab(url, options);
     }
 
-    return this.#window.gBrowser.addTab(item.url, options);
+    return this.#window.gBrowser.addTab(url, options);
   }
 
   #setParentTabAttribute(tab, parentTab) {

--- a/scripts/web-panels-runtime.uc.mjs
+++ b/scripts/web-panels-runtime.uc.mjs
@@ -1,3 +1,20 @@
+// A DOM attribute does not survive a restart — SessionStore persists only what
+// it is told to keep — so the tab that comes back has none of our marks and
+// reads as an ordinary tab. A custom tab value does survive, and carries the
+// panel id, which is what lets a restored tab be matched back to its panel.
+const PANEL_SESSION_KEY = "sineWebPanelBacking";
+const PANEL_TAB_ATTRIBUTE = "sine-web-panel-tab";
+const PANEL_ID_ATTRIBUTE = "sine-web-panel-id";
+const TAB_HIDE_OWNER = "sine-web-panels";
+
+// skipSessionStore so closing a panel does not push it into the recently-closed
+// tabs list, where it would look like something the user lost.
+const TAB_REMOVAL_OPTIONS = Object.freeze({
+  animate: false,
+  skipPermitUnload: true,
+  skipSessionStore: true,
+});
+
 export class WebPanelsRuntime {
   #window;
   #panels = new Map();
@@ -26,14 +43,49 @@ export class WebPanelsRuntime {
     }
 
     const tab = this.#createPanelTab(item, url ?? item.url);
-    tab.owner = null;
-    tab.setAttribute("sine-web-panel-tab", "true");
-    tab.setAttribute("sine-web-panel-id", item.id);
-    this.#setParentTabAttribute(tab, parentTab);
-
-    this.#window.gBrowser.hideTab?.(tab, "sine-web-panels");
-    this.#panels.set(item.id, { item, parentTab, tab });
+    this.#claimTab(tab, item, parentTab);
     return tab;
+  }
+
+  // Take a tab that came back from session restore and make it this panel's
+  // backing again, instead of leaving it loose in the tab strip while a second
+  // one gets created beside it.
+  //
+  // Adopting rather than deleting is deliberate. Sweeping would mean removing
+  // tabs automatically at startup on the strength of a marker, and one false
+  // positive there destroys a real tab with nothing to show for it. Adoption
+  // fails softly: the worst case is a tab that gets hidden and then appears in
+  // the rail, which is visible and reversible. Tabs that cannot be adopted —
+  // their panel is gone from the rail — are still swept, since nothing can
+  // ever surface them again.
+  adoptRestoredTabs(items = []) {
+    const wanted = new Map(items.filter(item => item?.id).map(item => [item.id, item]));
+    const adopted = [];
+    const swept = [];
+
+    for (const tab of this.#allTabs()) {
+      if (!tab || tab.closing) {
+        continue;
+      }
+
+      const panelId = this.#backingPanelId(tab);
+      if (!panelId) {
+        continue;
+      }
+
+      const item = wanted.get(panelId);
+      const live = this.#panels.get(panelId)?.tab;
+      if (!item || (live && live !== tab)) {
+        this.#removeTab(tab);
+        swept.push(panelId);
+        continue;
+      }
+
+      this.#claimTab(tab, item, this.#panels.get(panelId)?.parentTab ?? null);
+      adopted.push(panelId);
+    }
+
+    return { adopted, swept };
   }
 
   noteTabClosed(itemId) {
@@ -52,10 +104,7 @@ export class WebPanelsRuntime {
     }
 
     if (runtime.tab && !runtime.tab.closing) {
-      this.#window.gBrowser.removeTab(runtime.tab, {
-        animate: false,
-        skipPermitUnload: true,
-      });
+      this.#removeTab(runtime.tab);
     }
     this.#panels.delete(id);
   }
@@ -74,6 +123,57 @@ export class WebPanelsRuntime {
       this.unload(id);
     }
     this.#window = null;
+  }
+
+  #claimTab(tab, item, parentTab = null) {
+    tab.owner = null;
+    tab.setAttribute(PANEL_TAB_ATTRIBUTE, "true");
+    tab.setAttribute(PANEL_ID_ATTRIBUTE, item.id);
+    this.#setParentTabAttribute(tab, parentTab);
+    this.#markBackingTab(tab, item.id);
+
+    this.#window.gBrowser.hideTab?.(tab, TAB_HIDE_OWNER);
+    this.#panels.set(item.id, { item, parentTab, tab });
+  }
+
+  #allTabs() {
+    // A snapshot: sweeping mutates the live collection while we walk it.
+    return [...(this.#window?.gBrowser?.tabs ?? [])];
+  }
+
+  #removeTab(tab) {
+    this.#window?.gBrowser?.removeTab?.(tab, TAB_REMOVAL_OPTIONS);
+  }
+
+  // The session value is the one that survives a restart, so it is asked first;
+  // the attribute answers for tabs this session created.
+  #backingPanelId(tab) {
+    const sessionStore = this.#window?.SessionStore;
+    if (typeof sessionStore?.getCustomTabValue === "function") {
+      try {
+        const stored = sessionStore.getCustomTabValue(tab, PANEL_SESSION_KEY);
+        if (stored) {
+          return stored;
+        }
+      } catch (error) {
+        console.error("[Web Panels] Could not read a tab's panel marker.", error);
+      }
+    }
+
+    return tab?.getAttribute?.(PANEL_ID_ATTRIBUTE) || null;
+  }
+
+  #markBackingTab(tab, panelId) {
+    const sessionStore = this.#window?.SessionStore;
+    if (typeof sessionStore?.setCustomTabValue !== "function") {
+      return;
+    }
+
+    try {
+      sessionStore.setCustomTabValue(tab, PANEL_SESSION_KEY, panelId);
+    } catch (error) {
+      console.error("[Web Panels] Could not mark a panel tab for session restore.", error);
+    }
   }
 
   #createPanelTab(item, url) {

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -3,6 +3,87 @@ export const SEPARATOR_TYPE = "separator";
 export const MIN_PANEL_WIDTH = 320;
 export const DEFAULT_PANEL_WIDTH = 420;
 
+// Panel geometry.
+//
+// Ported from Tom Bar-Gal's ai/local-hardened-baseline branch, which solved
+// this properly: the panel's maximum width has to come from the page viewport
+// Zen actually gives the content, not from window.innerWidth. innerWidth is
+// the whole chrome window, so Zen's left tab sidebar is never subtracted and
+// the panel is free to grow over it.
+//
+// Both functions are pure so the arithmetic can be tested without a browser —
+// the measuring is the caller's job.
+export const PANEL_VIEWPORT_INSET = 8;
+export const PANEL_VIEWPORT_MAX_WIDTH_RATIO = 0.95;
+
+function positiveNumber(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function finiteNumber(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+// Intersect a measured rect with a fallback viewport, so a missing or nonsense
+// measurement degrades to the window rather than to zero.
+export function calculateWebPanelViewportGeometry(rect, fallbackViewport = {}) {
+  const top = finiteNumber(rect?.top, 0);
+  const left = finiteNumber(rect?.left, 0);
+  const width = positiveNumber(rect?.width, positiveNumber(fallbackViewport.width, 1));
+  const height = positiveNumber(
+    rect?.height,
+    positiveNumber(fallbackViewport.height, PANEL_VIEWPORT_INSET * 2)
+  );
+
+  const fallbackTop = finiteNumber(fallbackViewport.top, top);
+  const fallbackLeft = finiteNumber(fallbackViewport.left, left);
+  const fallbackWidth = positiveNumber(fallbackViewport.width, width);
+  const fallbackHeight = positiveNumber(fallbackViewport.height, height);
+
+  const visibleTop = Math.max(top, fallbackTop);
+  const visibleBottom = Math.min(top + height, fallbackTop + fallbackHeight);
+  const visibleLeft = Math.max(left, fallbackLeft);
+  const visibleRight = Math.min(left + width, fallbackLeft + fallbackWidth);
+  const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+  const visibleWidth = Math.max(0, visibleRight - visibleLeft);
+
+  return {
+    top: visibleTop + PANEL_VIEWPORT_INSET,
+    height: Math.max(0, visibleHeight - PANEL_VIEWPORT_INSET * 2),
+    maxWidth: Math.max(1, Math.floor(visibleWidth * PANEL_VIEWPORT_MAX_WIDTH_RATIO)),
+  };
+}
+
+// Turn a measured rect into a maximum, or null when the measurement cannot be
+// trusted. Two ways it cannot: no rect at all (nothing laid out yet), or a
+// maximum below the minimum panel width — which never means "the window is
+// tiny", it means we measured the wrong element. Trusting either would be
+// worse than not clamping: falling back to the whole window is how the panel
+// ends up over Zen's sidebar, and a maximum under the minimum pins every
+// clamp to a single value and freezes the resizer.
+export function panelMaxWidthFromViewport(rect, fallbackViewport, minWidth = MIN_PANEL_WIDTH) {
+  if (!rect || !(Number(rect.width) > 0)) {
+    return null;
+  }
+
+  const { maxWidth } = calculateWebPanelViewportGeometry(rect, fallbackViewport);
+  return maxWidth >= minWidth ? maxWidth : null;
+}
+
+// The minimum yields to the maximum: on a window too narrow for MIN_PANEL_WIDTH
+// a panel that overflows the viewport is worse than one below its floor.
+export function clampWebPanelWidth(width, maxWidth, minWidth = MIN_PANEL_WIDTH) {
+  const safeMax = Math.max(1, Math.floor(Number(maxWidth) || 1));
+  const safeMin = Math.min(
+    safeMax,
+    Math.max(1, Math.round(Number(minWidth) || MIN_PANEL_WIDTH))
+  );
+  const requested = Number.isFinite(Number(width)) ? Math.round(Number(width)) : safeMin;
+  return Math.min(safeMax, Math.max(safeMin, requested));
+}
+
 const PREFS = Object.freeze({
   enabled: "sine.web-panels.enabled",
   collapsed: "sine.web-panels.collapsed",

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -92,7 +92,34 @@ const PREFS = Object.freeze({
   shortcutModifier: "sine.web-panels.shortcut-modifier",
   lastUrls: "sine.web-panels.last-urls",
   lastTitles: "sine.web-panels.last-titles",
+  resizerColor: "sine.web-panels.resizer-color",
 });
+
+// The resize handle's colour is the one setting that becomes CSS, so it is
+// validated rather than trusted. Empty means "follow the theme", which is the
+// default and the way back from any custom value.
+//
+// Hex and bare identifiers cover named colours; the functional forms are
+// allowed with a deliberately narrow character set. No quotes, semicolons,
+// braces or url() get through, so nothing here can escape the declaration it
+// is written into.
+const COLOR_FUNCTIONS = "rgba?|hsla?|hwb|lab|lch|oklab|oklch";
+const COLOR_PATTERNS = Object.freeze([
+  /^#[0-9a-f]{3,4}$/i,
+  /^#[0-9a-f]{6}$/i,
+  /^#[0-9a-f]{8}$/i,
+  /^[a-z]+$/i,
+  new RegExp(`^(?:${COLOR_FUNCTIONS})\\([0-9a-z%.,\\s/+-]*\\)$`, "i"),
+]);
+
+export function normalizeResizerColor(value) {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return COLOR_PATTERNS.some(pattern => pattern.test(trimmed)) ? trimmed : "";
+}
 
 // "accel" is the platform's primary modifier: Cmd on macOS, Ctrl elsewhere —
 // the same concept Gecko uses for key elements, so a single setting is correct
@@ -244,6 +271,15 @@ export class WebPanelsStore {
   set width(value) {
     const width = Math.max(MIN_PANEL_WIDTH, Math.round(Number(value) || DEFAULT_PANEL_WIDTH));
     setStringPref(PREFS.width, String(width));
+  }
+
+  // "" means the accent falls back to its theme chain in the stylesheet.
+  get resizerColor() {
+    return normalizeResizerColor(readStringPref(PREFS.resizerColor, ""));
+  }
+
+  set resizerColor(value) {
+    setStringPref(PREFS.resizerColor, normalizeResizerColor(value));
   }
 
   get shortcutModifier() {

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -8,6 +8,7 @@ const PREFS = Object.freeze({
   width: "sine.web-panels.width",
   items: "sine.web-panels.items",
   shortcutModifier: "sine.web-panels.shortcut-modifier",
+  lastUrls: "sine.web-panels.last-urls",
 });
 
 // "accel" is the platform's primary modifier: Cmd on macOS, Ctrl elsewhere —
@@ -156,6 +157,52 @@ export class WebPanelsStore {
 
   set shortcutModifier(value) {
     setStringPref(PREFS.shortcutModifier, normalizeShortcutModifier(value));
+  }
+
+  // Where each panel actually was, keyed by panel id. Deliberately a separate
+  // pref from `items`: items is user configuration (order, titles, home urls),
+  // and folding volatile navigation state into it would rewrite the whole rail
+  // on every page change.
+  get lastUrls() {
+    try {
+      const parsed = JSON.parse(readStringPref(PREFS.lastUrls, "{}"));
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  set lastUrls(value) {
+    setStringPref(PREFS.lastUrls, JSON.stringify(value ?? {}));
+  }
+
+  // The URL a panel should open on: where it was last, falling back to its
+  // configured home.
+  resolveUrl(item) {
+    const remembered = normalizeWebPanelUrl(this.lastUrls[item.id]);
+    return remembered ?? item.url;
+  }
+
+  rememberUrl(id, rawUrl) {
+    const url = normalizeWebPanelUrl(rawUrl);
+    if (!url || !id) {
+      return;
+    }
+    const next = this.lastUrls;
+    if (next[id] === url) {
+      return;
+    }
+    next[id] = url;
+    this.lastUrls = next;
+  }
+
+  forgetUrl(id) {
+    const next = this.lastUrls;
+    if (!(id in next)) {
+      return;
+    }
+    delete next[id];
+    this.lastUrls = next;
   }
 
   get items() {

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -112,6 +112,14 @@ const COLOR_PATTERNS = Object.freeze([
   new RegExp(`^(?:${COLOR_FUNCTIONS})\\([0-9a-z%.,\\s/+-]*\\)$`, "i"),
 ]);
 
+// Zen stamps :root[zen-right-side="true"] when its sidebar is on the right, and
+// the rail takes the side the sidebar is NOT on. The inversion is the whole
+// point and is easy to get backwards in a refactor, so it lives here where a
+// test can hold it still.
+export function webPanelSideForSidebar(zenRightSide) {
+  return String(zenRightSide) === "true" ? "left" : "right";
+}
+
 export function normalizeResizerColor(value) {
   const trimmed = String(value ?? "").trim();
   if (!trimmed) {

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -7,7 +7,19 @@ const PREFS = Object.freeze({
   enabled: "sine.web-panels.enabled",
   width: "sine.web-panels.width",
   items: "sine.web-panels.items",
+  shortcutModifier: "sine.web-panels.shortcut-modifier",
 });
+
+export const SHORTCUT_MODIFIERS = Object.freeze([
+  "disabled",
+  "ctrl",
+  "ctrl+alt",
+  "ctrl+shift",
+  "alt",
+  "alt+shift",
+]);
+
+export const DEFAULT_SHORTCUT_MODIFIER = "ctrl+alt";
 
 function generateId(prefix = "item") {
   if (globalThis.crypto?.randomUUID) {
@@ -119,6 +131,18 @@ export class WebPanelsStore {
   set width(value) {
     const width = Math.max(MIN_PANEL_WIDTH, Math.round(Number(value) || DEFAULT_PANEL_WIDTH));
     setStringPref(PREFS.width, String(width));
+  }
+
+  get shortcutModifier() {
+    const value = readStringPref(PREFS.shortcutModifier, DEFAULT_SHORTCUT_MODIFIER);
+    return SHORTCUT_MODIFIERS.includes(value) ? value : DEFAULT_SHORTCUT_MODIFIER;
+  }
+
+  set shortcutModifier(value) {
+    setStringPref(
+      PREFS.shortcutModifier,
+      SHORTCUT_MODIFIERS.includes(value) ? value : DEFAULT_SHORTCUT_MODIFIER
+    );
   }
 
   get items() {

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -9,6 +9,7 @@ const PREFS = Object.freeze({
   items: "sine.web-panels.items",
   shortcutModifier: "sine.web-panels.shortcut-modifier",
   lastUrls: "sine.web-panels.last-urls",
+  lastTitles: "sine.web-panels.last-titles",
 });
 
 // "accel" is the platform's primary modifier: Cmd on macOS, Ctrl elsewhere —
@@ -116,6 +117,9 @@ function sanitizeItem(item) {
     type: PANEL_TYPE,
     id,
     title: typeof item.title === "string" && item.title.trim() ? item.title.trim() : titleFromUrl(url),
+    // A name the user typed, kept apart from `title` so that re-deriving the
+    // title from the URL can never silently discard it.
+    name: typeof item.name === "string" && item.name.trim() ? item.name.trim() : undefined,
     url,
   };
 }
@@ -205,6 +209,43 @@ export class WebPanelsStore {
     this.lastUrls = next;
   }
 
+  // Panels are titled by hostname ("mail.google.com"), which is not what anyone
+  // searches for. Remember the page's own title so the finder can match "gmail".
+  get lastTitles() {
+    try {
+      const parsed = JSON.parse(readStringPref(PREFS.lastTitles, "{}"));
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  set lastTitles(value) {
+    setStringPref(PREFS.lastTitles, JSON.stringify(value ?? {}));
+  }
+
+  rememberTitle(id, title) {
+    const clean = (title ?? "").trim();
+    if (!id || !clean) {
+      return;
+    }
+    const next = this.lastTitles;
+    if (next[id] === clean) {
+      return;
+    }
+    next[id] = clean;
+    this.lastTitles = next;
+  }
+
+  forgetTitle(id) {
+    const next = this.lastTitles;
+    if (!(id in next)) {
+      return;
+    }
+    delete next[id];
+    this.lastTitles = next;
+  }
+
   get items() {
     return this.loadItems();
   }
@@ -233,7 +274,7 @@ export class WebPanelsStore {
     return sanitized;
   }
 
-  createPanel(rawUrl) {
+  createPanel(rawUrl, name = "") {
     const url = normalizeWebPanelUrl(rawUrl);
     if (!url) {
       return null;
@@ -242,6 +283,7 @@ export class WebPanelsStore {
       type: PANEL_TYPE,
       id: generateId("panel"),
       title: titleFromUrl(url),
+      name: name.trim() || undefined,
       url,
     };
   }
@@ -261,7 +303,7 @@ export class WebPanelsStore {
     return nextItems;
   }
 
-  updatePanel(id, rawUrl) {
+  updatePanel(id, rawUrl, name = null) {
     const url = normalizeWebPanelUrl(rawUrl);
     if (!url) {
       return null;
@@ -276,6 +318,7 @@ export class WebPanelsStore {
     nextItems[index] = {
       ...nextItems[index],
       title: titleFromUrl(url),
+      name: name === null ? nextItems[index].name : (name.trim() || undefined),
       url,
     };
     this.items = nextItems;

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -5,6 +5,7 @@ export const DEFAULT_PANEL_WIDTH = 420;
 
 const PREFS = Object.freeze({
   enabled: "sine.web-panels.enabled",
+  collapsed: "sine.web-panels.collapsed",
   width: "sine.web-panels.width",
   items: "sine.web-panels.items",
   shortcutModifier: "sine.web-panels.shortcut-modifier",
@@ -141,6 +142,17 @@ export class WebPanelsStore {
 
   set enabled(value) {
     Services.prefs.setBoolPref(PREFS.enabled, Boolean(value));
+  }
+
+  // Collapsed is not "disabled": the rail is out of sight and gives its strip
+  // of window back, but every panel stays loaded and one hover at the window
+  // edge brings it in. Disabling tears the runtime down.
+  get collapsed() {
+    return Services.prefs.getBoolPref(PREFS.collapsed, false);
+  }
+
+  set collapsed(value) {
+    Services.prefs.setBoolPref(PREFS.collapsed, Boolean(value));
   }
 
   get width() {

--- a/scripts/web-panels-store.uc.mjs
+++ b/scripts/web-panels-store.uc.mjs
@@ -10,16 +10,31 @@ const PREFS = Object.freeze({
   shortcutModifier: "sine.web-panels.shortcut-modifier",
 });
 
+// "accel" is the platform's primary modifier: Cmd on macOS, Ctrl elsewhere —
+// the same concept Gecko uses for key elements, so a single setting is correct
+// on every platform.
 export const SHORTCUT_MODIFIERS = Object.freeze([
   "disabled",
-  "ctrl",
-  "ctrl+alt",
-  "ctrl+shift",
+  "accel",
+  "accel+alt",
+  "accel+shift",
   "alt",
   "alt+shift",
 ]);
 
-export const DEFAULT_SHORTCUT_MODIFIER = "ctrl+alt";
+export const DEFAULT_SHORTCUT_MODIFIER = "accel+alt";
+
+// Values written before the setting became platform-neutral.
+const LEGACY_SHORTCUT_MODIFIERS = Object.freeze({
+  ctrl: "accel",
+  "ctrl+alt": "accel+alt",
+  "ctrl+shift": "accel+shift",
+});
+
+export function normalizeShortcutModifier(value) {
+  const migrated = LEGACY_SHORTCUT_MODIFIERS[value] ?? value;
+  return SHORTCUT_MODIFIERS.includes(migrated) ? migrated : DEFAULT_SHORTCUT_MODIFIER;
+}
 
 function generateId(prefix = "item") {
   if (globalThis.crypto?.randomUUID) {
@@ -134,15 +149,13 @@ export class WebPanelsStore {
   }
 
   get shortcutModifier() {
-    const value = readStringPref(PREFS.shortcutModifier, DEFAULT_SHORTCUT_MODIFIER);
-    return SHORTCUT_MODIFIERS.includes(value) ? value : DEFAULT_SHORTCUT_MODIFIER;
+    return normalizeShortcutModifier(
+      readStringPref(PREFS.shortcutModifier, DEFAULT_SHORTCUT_MODIFIER)
+    );
   }
 
   set shortcutModifier(value) {
-    setStringPref(
-      PREFS.shortcutModifier,
-      SHORTCUT_MODIFIERS.includes(value) ? value : DEFAULT_SHORTCUT_MODIFIER
-    );
+    setStringPref(PREFS.shortcutModifier, normalizeShortcutModifier(value));
   }
 
   get items() {

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -7,6 +7,11 @@
   --sine-web-panels-offset: var(--sine-web-panels-visible-rail-size);
   --sine-web-panels-panel-offset: var(--sine-web-panels-gap);
   --sine-web-panels-resizer-width: 8px;
+  /* The visible mark on the handle. Half again as wide once it is live, so
+     "you can grab this" is legible at a glance rather than on inspection. */
+  --sine-web-panels-resizer-line: 2px;
+  --sine-web-panels-resizer-line-active: 3px;
+  --sine-web-panels-resizer-line-dragging: 4px;
   /* The strip a collapsed rail listens on. Kept narrow: it sits over the page,
      so every pixel of it is a pixel of scrollbar the page does not get. */
   --sine-web-panels-edge-size: 6px;
@@ -436,8 +441,8 @@ tab[sine-web-panel-tab="true"] {
   content: "";
   position: absolute;
   inset-block: 0;
-  width: 2px;
-  border-radius: 2px;
+  width: var(--sine-web-panels-resizer-line);
+  border-radius: var(--sine-web-panels-resizer-line);
   background: var(--sine-web-panels-accent);
   box-shadow: 0 0 6px color-mix(in srgb, var(--sine-web-panels-accent) 65%, transparent);
   opacity: 0;
@@ -476,13 +481,17 @@ tab[sine-web-panel-tab="true"] {
 #sine-web-panels-resizer:hover::before,
 :root[sine-web-panels-resizer-hover="true"] #sine-web-panels-resizer::before,
 :root:has(#sine-web-panels-root[resizing]) #sine-web-panels-resizer::before {
+  width: var(--sine-web-panels-resizer-line-active);
+  border-radius: var(--sine-web-panels-resizer-line-active);
   opacity: 1;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--sine-web-panels-accent) 75%, transparent);
 }
 
 /* Grabbed, not just pointed at. */
 :root:has(#sine-web-panels-root[resizing]) #sine-web-panels-resizer::before {
-  width: 3px;
-  box-shadow: 0 0 12px color-mix(in srgb, var(--sine-web-panels-accent) 80%, transparent);
+  width: var(--sine-web-panels-resizer-line-dragging);
+  border-radius: var(--sine-web-panels-resizer-line-dragging);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--sine-web-panels-accent) 85%, transparent);
 }
 
 .browserSidebarContainer.sine-web-panels-parent-background {

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -1,4 +1,15 @@
 :root {
+  /* Every popup of ours (menu, finder, Add/Edit) paints on this. Opaque on
+     purpose: Zen's own arrow panels follow its translucent primary colour and
+     the page read through the fields. --zen-dialog-background is the solid
+     Zen uses for its dialogs; the fallback matches its values.
+     On :root, not on the rail: the Add/Edit panel hangs off mainPopupSet and
+     inherits nothing from #sine-web-panels-root — a token defined there is
+     invalid inside the popup, and an invalid background paints transparent. */
+  --sine-web-panels-opaque-surface: var(
+    --zen-dialog-background,
+    light-dark(rgb(250, 251, 255), rgb(28, 28, 28))
+  );
   --sine-web-panels-rail-size: 36px;
   --sine-web-panels-gap: 6px;
   --sine-web-panels-visible-rail-size: calc(
@@ -591,10 +602,33 @@ tab[sine-web-panel-tab="true"] {
   -moz-appearance: none;
   box-sizing: border-box;
   --sine-web-panels-panel-color: var(--arrowpanel-color, CanvasText);
+  /* Toolkit paints ::part(content) with --panel-background-color, and Zen
+     points that at its translucent primary colour. Sine loads this sheet at
+     user level, so the override needs !important to beat Zen's author rule. */
+  --panel-background-color: var(--sine-web-panels-opaque-surface) !important;
+  --arrowpanel-background: var(--sine-web-panels-opaque-surface) !important;
+  /* Toolkit keeps a transparent 8px ring around an arrow panel for its
+     shadow, and the page shows through that ring. Against a dark page the
+     ring plus a near-identical grey read as a translucent popup. No ring:
+     the popup's box is exactly its content, painted on the host as well so
+     the result does not depend on ::part(content) matching. */
+  --panel-box-shadow-margin: 0px !important;
+  background: var(--sine-web-panels-opaque-surface) !important;
+  /* Direct values, for the same reason: the rail's border and radius tokens
+     do not reach this element. */
+  border: 1px solid color-mix(in srgb, currentColor 18%, transparent) !important;
+  border-radius: var(--panel-border-radius, 12px) !important;
   color: var(--sine-web-panels-panel-color);
   font: menu;
 }
 
+#sine-web-panels-editor::part(content) {
+  background: var(--sine-web-panels-opaque-surface) !important;
+  backdrop-filter: none !important;
+  box-shadow: none !important;
+}
+
+/* Add: [ URL ........ ][ Add ]. Edit: the same row, with Name under it. */
 #sine-web-panels-editor-content {
   box-sizing: border-box;
   width: min(520px, calc(100vw - 32px));
@@ -607,7 +641,24 @@ tab[sine-web-panel-tab="true"] {
   font: menu;
 }
 
-#sine-web-panels-url-input {
+#sine-web-panels-editor-submit {
+  grid-column: 2;
+  justify-self: end;
+}
+
+/* In Edit the URL spans the row like Name does, so the two fields line up
+   and Save drops to its own row on the right. */
+#sine-web-panels-editor[mode="edit"] #sine-web-panels-url-input,
+#sine-web-panels-name-input {
+  grid-column: 1 / -1;
+}
+
+#sine-web-panels-name-input[hidden] {
+  display: none;
+}
+
+#sine-web-panels-url-input,
+#sine-web-panels-name-input {
   appearance: none;
   -moz-appearance: none;
   box-sizing: border-box;
@@ -625,14 +676,16 @@ tab[sine-web-panel-tab="true"] {
   caret-color: currentColor;
 }
 
-#sine-web-panels-url-input:hover {
+#sine-web-panels-url-input:hover,
+#sine-web-panels-name-input:hover {
   background: var(
     --button-background-color-ghost-hover,
     color-mix(in srgb, currentColor 10%, transparent)
   );
 }
 
-#sine-web-panels-url-input:focus {
+#sine-web-panels-url-input:focus,
+#sine-web-panels-name-input:focus {
   background: var(
     --button-background-color-ghost-hover,
     color-mix(in srgb, currentColor 10%, transparent)
@@ -701,12 +754,11 @@ tab[sine-web-panel-tab="true"] {
   padding: 6px;
   border: 1px solid var(--sine-web-panels-panel-border);
   border-radius: var(--sine-web-panels-panel-radius);
-  background: var(--sine-web-panels-panel-background);
+  background: var(--sine-web-panels-opaque-surface);
   color: var(--sine-web-panels-panel-color);
   box-shadow:
     0 0 0 1px color-mix(in srgb, white 4%, transparent) inset,
     var(--windows-panel-box-shadow, var(--sine-web-panels-shadow));
-  backdrop-filter: blur(24px) saturate(140%) brightness(1.08);
   font: menu;
   pointer-events: auto;
 }
@@ -863,7 +915,7 @@ tab[sine-web-panel-tab="true"] {
   gap: 6px;
   padding: 8px;
   border-radius: 10px;
-  background: var(--zen-themed-toolbar-bg, Field);
+  background: var(--sine-web-panels-opaque-surface);
   color: FieldText;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
 }
@@ -979,3 +1031,4 @@ tab[sine-web-panel-tab="true"] {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -19,6 +19,16 @@
     transparent
   );
   --sine-web-panels-border: color-mix(in srgb, currentColor 14%, transparent);
+  /* The resize handle's colour. Follows Zen's theme where Zen exposes it, then
+     the browser theme, then the system — an invisible handle is the whole bug
+     this exists to fix, so the chain must not be able to end in nothing. */
+  --sine-web-panels-accent: var(
+    --zen-primary-color,
+    var(
+      --zen-colors-primary,
+      var(--toolbarbutton-icon-fill-attention, var(--focus-outline-color, AccentColor))
+    )
+  );
   --sine-web-panels-radius: var(--zen-native-inner-radius, 12px);
   --sine-web-panels-shadow: var(
     --zen-big-shadow,
@@ -411,22 +421,31 @@ tab[sine-web-panel-tab="true"] {
   z-index: 2147483647;
   cursor: ew-resize;
   background: transparent;
-  pointer-events: none;
+  /* Must stay `auto`. The handle straddles the panel's edge, and both sides of
+     it are remote content — chrome sees no pointer moves over that, so the
+     JS-driven hover state alone almost never fires and the affordance never
+     appeared. Hit-testing this element is what makes :hover and the ew-resize
+     cursor work at all. */
+  pointer-events: auto;
   transform: translateX(-50%);
 }
 
+/* The line itself: full height, so the edge of the panel lights up rather than
+   a stub in the middle of it. */
 #sine-web-panels-resizer::before {
   content: "";
   position: absolute;
-  top: 50%;
+  inset-block: 0;
   width: 2px;
-  height: 50px;
   border-radius: 2px;
-  background: color-mix(in srgb, AccentColor 75%, transparent);
+  background: var(--sine-web-panels-accent);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--sine-web-panels-accent) 65%, transparent);
   opacity: 0;
   pointer-events: none;
-  transform: translateY(-50%);
-  transition: opacity 80ms ease-in-out;
+  transition:
+    opacity 80ms ease-in-out,
+    width 80ms ease-in-out,
+    box-shadow 80ms ease-in-out;
 }
 
 :root[sine-web-panels-side="right"] #sine-web-panels-resizer {
@@ -458,6 +477,12 @@ tab[sine-web-panel-tab="true"] {
 :root[sine-web-panels-resizer-hover="true"] #sine-web-panels-resizer::before,
 :root:has(#sine-web-panels-root[resizing]) #sine-web-panels-resizer::before {
   opacity: 1;
+}
+
+/* Grabbed, not just pointed at. */
+:root:has(#sine-web-panels-root[resizing]) #sine-web-panels-resizer::before {
+  width: 3px;
+  box-shadow: 0 0 12px color-mix(in srgb, var(--sine-web-panels-accent) 80%, transparent);
 }
 
 .browserSidebarContainer.sine-web-panels-parent-background {

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -760,48 +760,56 @@ tab[sine-web-panel-tab="true"] {
 }
 
 /* --------------------------------------------------------------------------
-   Panel navigation bar
-   Sits over the top edge of the panel and only appears while the panel is
-   hovered, so a panel being read shows no chrome at all.
+   Panel navigation controls
+   A small pill floating just outside the panel's outer edge, past the resize
+   handle, so it never sits over the panel's content or over Zen's toolbar.
+   Always shown while a panel is open: controls that come and go are harder
+   to trust than ones that stay put. It is positioned off the panel frame, so
+   it rides the edge during a resize instead of lagging behind it.
    -------------------------------------------------------------------------- */
 .sine-web-panels-nav {
   position: absolute;
-  inset-block-start: 0;
-  inset-inline: 0;
+  inset-block-start: 10px;
   z-index: 3;
   display: flex;
+  flex-direction: column;
   gap: 2px;
-  padding: 4px 6px;
-  opacity: 0;
-  transform: translateY(-4px);
-  transition: opacity 120ms ease-out, transform 120ms ease-out;
-  pointer-events: none;
-  background: linear-gradient(
-    to bottom,
-    color-mix(in srgb, var(--zen-themed-toolbar-bg, Field) 92%, transparent),
-    transparent
-  );
-}
-
-.browserContainer:hover > .sine-web-panels-nav,
-.sine-web-panels-nav:focus-within {
-  opacity: 1;
-  transform: none;
+  padding: 3px;
+  border-radius: 9px;
+  background: var(--zen-themed-toolbar-bg, Field);
+  color: FieldText;
+  border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28);
   pointer-events: auto;
 }
 
+:root[sine-web-panels-side="right"] .sine-web-panels-nav {
+  inset-inline-end: calc(100% + var(--sine-web-panels-resizer-width) + 4px);
+}
+
+:root[sine-web-panels-side="left"] .sine-web-panels-nav {
+  inset-inline-start: calc(100% + var(--sine-web-panels-resizer-width) + 4px);
+}
+
+/* The panel owns the whole window while a video from it is fullscreen; there
+   is no edge to sit beside. */
+:root[sine-web-panels-panel-fullscreen] .sine-web-panels-nav {
+  display: none;
+}
+
 .sine-web-panels-nav-button {
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   padding: 0;
   border: 0;
-  border-radius: 4px;
+  border-radius: 6px;
   background: transparent;
+  color: inherit;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 0;
-  opacity: 0.75;
+  opacity: 0.8;
   -moz-context-properties: fill;
 }
 
@@ -809,8 +817,8 @@ tab[sine-web-panel-tab="true"] {
    <button> paints its own background over a mask applied directly to it. */
 .sine-web-panels-nav-button::before {
   content: "";
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   display: block;
   background-color: currentColor;
 }
@@ -821,19 +829,23 @@ tab[sine-web-panel-tab="true"] {
 }
 
 .sine-web-panels-nav-button:disabled {
-  opacity: 0.25;
+  opacity: 0.3;
 }
 
 .sine-web-panels-nav-back::before {
-  mask: url("chrome://browser/skin/zen-icons/back.svg") center / 12px 12px no-repeat;
+  mask: url("chrome://browser/skin/zen-icons/back.svg") center / 14px 14px no-repeat;
 }
 
 .sine-web-panels-nav-forward::before {
-  mask: url("chrome://browser/skin/zen-icons/forward.svg") center / 12px 12px no-repeat;
+  mask: url("chrome://browser/skin/zen-icons/forward.svg") center / 14px 14px no-repeat;
+}
+
+.sine-web-panels-nav-reload::before {
+  mask: url("chrome://browser/skin/zen-icons/reload.svg") center / 14px 14px no-repeat;
 }
 
 .sine-web-panels-nav-home::before {
-  mask: url("chrome://browser/skin/zen-icons/home.svg") center / 12px 12px no-repeat;
+  mask: url("chrome://browser/skin/zen-icons/home.svg") center / 14px 14px no-repeat;
 }
 
 /* --------------------------------------------------------------------------

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -698,3 +698,135 @@ tab[sine-web-panel-tab="true"] {
 .sine-web-panels-nav-home::before {
   mask: url("chrome://browser/skin/zen-icons/home.svg") center / 12px 12px no-repeat;
 }
+
+/* --------------------------------------------------------------------------
+   Panel finder — a filter over the rail. Opened with the panel shortcut
+   modifier + P; searches every configured panel, not just loaded ones.
+   -------------------------------------------------------------------------- */
+#sine-web-panels-finder {
+  position: fixed;
+  z-index: 10001;
+  inset-block-start: var(--sine-web-panels-gap);
+  width: 320px;
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border-radius: 10px;
+  background: var(--zen-themed-toolbar-bg, Field);
+  color: FieldText;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+#sine-web-panels-finder[hidden] {
+  display: none;
+}
+
+:root[sine-web-panels-side="right"] #sine-web-panels-finder {
+  inset-inline-end: calc(var(--sine-web-panels-rail-size) + var(--sine-web-panels-gap) * 2);
+}
+
+:root[sine-web-panels-side="left"] #sine-web-panels-finder {
+  inset-inline-start: calc(var(--sine-web-panels-rail-size) + var(--sine-web-panels-gap) * 2);
+}
+
+#sine-web-panels-finder > input {
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  background: transparent;
+  color: inherit;
+}
+
+.sine-web-panels-finder-list {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sine-web-panels-finder-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  text-align: start;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sine-web-panels-finder-row:hover {
+  background: var(--sine-web-panels-hover);
+}
+
+/* The keyboard selection has to read differently from a mouse hover, otherwise
+   arrowing through the list looks like nothing is happening. */
+.sine-web-panels-finder-row[selected] {
+  background: var(--sine-web-panels-active, var(--sine-web-panels-hover));
+  outline: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+  outline-offset: -1px;
+}
+
+.sine-web-panels-finder-row .sine-web-panels-favicon {
+  width: 16px;
+  height: 16px;
+  flex: none;
+}
+
+/* Finder group headers: web panels first, then one per space. */
+.sine-web-panels-finder-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 8px 4px;
+  font-size: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.6;
+  position: sticky;
+  inset-block-start: 0;
+  background: var(--zen-themed-toolbar-bg, Field);
+}
+
+.sine-web-panels-finder-group-icon {
+  font-size: 1.1em;
+  opacity: 0.9;
+}
+
+.sine-web-panels-finder-group-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The open-a-new-page fallback reads as an action, not a result. */
+.sine-web-panels-finder-open {
+  font-style: italic;
+  opacity: 0.85;
+}
+
+/* Folder breadcrumb on a finder row: the space is the group header, so the row
+   only needs to add the folder to complete Space / Folder / tab. */
+.sine-web-panels-finder-folder {
+  flex: none;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.55;
+}
+
+.sine-web-panels-finder-folder::after {
+  content: " / ";
+  opacity: 0.7;
+}
+
+.sine-web-panels-finder-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -124,8 +124,16 @@
   inset-inline-start: var(--sine-web-panels-gap);
 }
 
-#sine-web-panels-root[disabled] {
+#sine-web-panels-root[disabled],
+/* Fullscreen belongs to the page. The script drops the reserved margin (it is
+   an inline !important, unreachable from here) and sets this attribute. */
+#sine-web-panels-root[fullscreen] {
   display: none;
+}
+
+:root[inFullscreen] #sine-web-panels-resizer,
+:root[inDOMFullscreen] #sine-web-panels-resizer {
+  display: none !important;
 }
 
 #sine-web-panels-backdrop {
@@ -398,6 +406,14 @@ tab[sine-web-panel-tab="true"] {
 
 :root[sine-web-panels-side="left"] .browserSidebarContainer.sine-web-panels-overlay .browserContainer {
   inset-inline-start: var(--sine-web-panels-panel-offset) !important;
+}
+
+/* A video fullscreened from inside a panel: the panel keeps its browser, but
+   the pinned rail-side box has to give way to the whole window. */
+:root[sine-web-panels-panel-fullscreen] .browserSidebarContainer.sine-web-panels-overlay .browserContainer {
+  inset: 0 !important;
+  width: auto !important;
+  min-width: 0 !important;
 }
 
 #sine-web-panels-root[opening][side="right"] ~ .browserSidebarContainer.sine-web-panels-overlay .browserContainer,

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -7,6 +7,9 @@
   --sine-web-panels-offset: var(--sine-web-panels-visible-rail-size);
   --sine-web-panels-panel-offset: var(--sine-web-panels-gap);
   --sine-web-panels-resizer-width: 8px;
+  /* The strip a collapsed rail listens on. Kept narrow: it sits over the page,
+     so every pixel of it is a pixel of scrollbar the page does not get. */
+  --sine-web-panels-edge-size: 6px;
   --sine-web-panels-min-width: 320px;
   --sine-web-panels-width: 420px;
   --sine-web-panels-animation-duration: 75ms;
@@ -157,6 +160,7 @@
 }
 
 #sine-web-panels-backdrop[hidden],
+#sine-web-panels-edge[hidden],
 #sine-web-panels-resizer[hidden],
 #sine-web-panels-editor[hidden],
 #sine-web-panels-menu[hidden] {
@@ -193,6 +197,59 @@ tab[sine-web-panel-tab="true"] {
   inset-inline-start: var(--sine-web-panels-gap);
 }
 
+/* --------------------------------------------------------------------------
+   Collapsed rail + edge peek. Collapsed, the rail slides off its own side and
+   the script hands the reserved strip back to the content; the edge element
+   below is what the pointer has to reach to bring it in again.
+   -------------------------------------------------------------------------- */
+#sine-web-panels-rail {
+  transition:
+    translate var(--sine-web-panels-animation-duration) ease-out,
+    opacity var(--sine-web-panels-animation-duration) ease-out;
+}
+
+#sine-web-panels-root[collapsed] #sine-web-panels-rail {
+  opacity: 0;
+  pointer-events: none;
+}
+
+#sine-web-panels-root[collapsed][side="right"] #sine-web-panels-rail {
+  translate: var(--sine-web-panels-visible-rail-size) 0;
+}
+
+#sine-web-panels-root[collapsed][side="left"] #sine-web-panels-rail {
+  translate: calc(-1 * var(--sine-web-panels-visible-rail-size)) 0;
+}
+
+#sine-web-panels-root[collapsed][peeking] #sine-web-panels-rail {
+  translate: 0 0;
+  opacity: 1;
+  pointer-events: auto;
+  /* Peeked, the rail floats over the page rather than over chrome, so it needs
+     a surface of its own. Opaque, not translucent: the mod refuses blur
+     everywhere else, and a see-through rail over arbitrary content is a
+     coin toss on legibility. */
+  border-radius: var(--sine-web-panels-radius);
+  background: var(--sine-web-panels-panel-base);
+  box-shadow: var(--sine-web-panels-shadow);
+}
+
+#sine-web-panels-edge {
+  position: fixed;
+  inset-block: 0;
+  width: var(--sine-web-panels-edge-size);
+  background: transparent;
+  pointer-events: auto;
+}
+
+#sine-web-panels-root[side="right"] #sine-web-panels-edge {
+  inset-inline-end: 0;
+}
+
+#sine-web-panels-root[side="left"] #sine-web-panels-edge {
+  inset-inline-start: 0;
+}
+
 #sine-web-panels-list {
   width: 100%;
   min-height: 0;
@@ -206,7 +263,8 @@ tab[sine-web-panel-tab="true"] {
 }
 
 .sine-web-panels-item,
-#sine-web-panels-add-button {
+#sine-web-panels-add-button,
+#sine-web-panels-toggle {
   appearance: none;
   box-sizing: border-box;
   width: var(--sine-web-panels-button-size);
@@ -228,10 +286,37 @@ tab[sine-web-panel-tab="true"] {
   pointer-events: auto;
 }
 
-#sine-web-panels-add-button {
+#sine-web-panels-add-button,
+#sine-web-panels-toggle {
   font-size: 0;
   font-weight: 400;
   -moz-context-properties: fill;
+}
+
+/* The two-pane glyph Zen uses for its own sidebar button, mirrored to whichever
+   side the rail is on so the icon points at the edge it hides behind. Sits a
+   step back from the panels themselves — it is chrome for the rail, not one of
+   the things on it. */
+#sine-web-panels-toggle {
+  opacity: 0.7;
+}
+
+#sine-web-panels-toggle:hover,
+#sine-web-panels-root[collapsed] #sine-web-panels-toggle {
+  opacity: 1;
+}
+
+#sine-web-panels-toggle::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  display: block;
+  background-color: currentColor;
+  mask: url("chrome://browser/skin/zen-icons/sidebar.svg") center / 16px 16px no-repeat;
+}
+
+#sine-web-panels-root[side="right"] #sine-web-panels-toggle::before {
+  mask-image: url("chrome://browser/skin/zen-icons/sidebar-right.svg");
 }
 
 #sine-web-panels-add-button::before {
@@ -244,13 +329,15 @@ tab[sine-web-panel-tab="true"] {
 }
 
 .sine-web-panels-panel-button:hover,
-#sine-web-panels-add-button:hover {
+#sine-web-panels-add-button:hover,
+#sine-web-panels-toggle:hover {
   background: var(--sine-web-panels-hover);
 }
 
 .sine-web-panels-panel-button[active],
 .sine-web-panels-panel-button:active,
-#sine-web-panels-add-button:active {
+#sine-web-panels-add-button:active,
+#sine-web-panels-toggle:active {
   background: var(--sine-web-panels-active);
 }
 

--- a/scripts/web-panels.css
+++ b/scripts/web-panels.css
@@ -621,3 +621,80 @@ tab[sine-web-panel-tab="true"] {
     animation: none !important;
   }
 }
+
+/* --------------------------------------------------------------------------
+   Panel navigation bar
+   Sits over the top edge of the panel and only appears while the panel is
+   hovered, so a panel being read shows no chrome at all.
+   -------------------------------------------------------------------------- */
+.sine-web-panels-nav {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline: 0;
+  z-index: 3;
+  display: flex;
+  gap: 2px;
+  padding: 4px 6px;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 120ms ease-out, transform 120ms ease-out;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--zen-themed-toolbar-bg, Field) 92%, transparent),
+    transparent
+  );
+}
+
+.browserContainer:hover > .sine-web-panels-nav,
+.sine-web-panels-nav:focus-within {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+
+.sine-web-panels-nav-button {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0;
+  opacity: 0.75;
+  -moz-context-properties: fill;
+}
+
+/* The icon goes on ::before, matching #sine-web-panels-add-button: a chrome
+   <button> paints its own background over a mask applied directly to it. */
+.sine-web-panels-nav-button::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  display: block;
+  background-color: currentColor;
+}
+
+.sine-web-panels-nav-button:hover:not(:disabled) {
+  background: var(--sine-web-panels-hover);
+  opacity: 1;
+}
+
+.sine-web-panels-nav-button:disabled {
+  opacity: 0.25;
+}
+
+.sine-web-panels-nav-back::before {
+  mask: url("chrome://browser/skin/zen-icons/back.svg") center / 12px 12px no-repeat;
+}
+
+.sine-web-panels-nav-forward::before {
+  mask: url("chrome://browser/skin/zen-icons/forward.svg") center / 12px 12px no-repeat;
+}
+
+.sine-web-panels-nav-home::before {
+  mask: url("chrome://browser/skin/zen-icons/home.svg") center / 12px 12px no-repeat;
+}

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -147,6 +147,7 @@ export class SineWebPanels {
   #abortController = new AbortController();
   #prefObserver;
   #sessionRestoreObserver;
+  #correctingSelection = false;
   #resizeState = null;
   #resizeHovering = false;
   #dragState = null;
@@ -930,6 +931,20 @@ export class SineWebPanels {
     parentBrowser.docShellIsActive = true;
     panelBrowser.zenModeActive = true;
     panelBrowser.docShellIsActive = true;
+    // Recorded BEFORE the panel tab is selected. Selecting it fires TabSelect
+    // synchronously, and #onTabSelect reads this to tell the panel's own
+    // backing from a stray one — with it unset, the guard took the selection
+    // straight back off the panel that was opening, and every panel "opened"
+    // whichever ordinary tab came first in the strip.
+    this.#surfaceState = {
+      parentTab,
+      panelTab,
+      parentBrowser,
+      panelBrowser,
+      parentContainer,
+      panelContainer,
+      panelFrame,
+    };
     // Select the PANEL tab so WebExtensions resolve the panel's site:
     // tabs.query({active:true}) is how password managers pick a context, and
     // with the parent selected they offer credentials for the page behind the
@@ -942,16 +957,6 @@ export class SineWebPanels {
     if (parentTab) {
       parentTab._visuallySelected = true;
     }
-    this.#surfaceState = {
-      parentTab,
-      panelTab,
-      parentBrowser,
-      panelBrowser,
-      parentContainer,
-      panelContainer,
-      panelFrame,
-    };
-    // must run after #surfaceState exists — it reads parentContainer from it
     this.#keepParentPainted();
     return true;
   }
@@ -2020,12 +2025,34 @@ export class SineWebPanels {
   };
 
   #onTabSelect = () => {
+    const selected = this.window.gBrowser?.selectedTab ?? null;
+    // The surface, not #activeId: #openSurface selects the panel tab before
+    // #openPanel gets to assign #activeId, and the TabSelect lands in between.
+    const activePanelTab =
+      this.#surfaceState?.panelTab ?? (this.#activeId ? this.#runtime?.get(this.#activeId)?.tab : null);
+
+    // The address bar offers hidden tabs as switch-to-tab candidates —
+    // UrlbarProviderOpenTabs does not filter on hidden — so searching for a
+    // panel's own site lands the window on that panel's backing tab. There is
+    // no way out of that state by hand: the page fills the window with no
+    // panel around it, and no panel will open, because opening one needs a
+    // visible tab to anchor the overlay to and the selected tab is the panel.
+    // Restarting with a panel open used to arrive at the same place.
+    //
+    // Selecting a backing is only ever legitimate when it is the open panel's
+    // own, which #openSurface does deliberately so extensions resolve the
+    // panel's site.
+    if (selected && selected !== activePanelTab && this.#isPanelTab(selected)) {
+      this.#takeSelectionOffPanelTab(selected);
+      return;
+    }
+
     if (!this.#activeId) {
       return;
     }
 
-    const selectedTab = this.window.gBrowser?.selectedTab;
-    const panelTab = this.#runtime?.get(this.#activeId)?.tab;
+    const selectedTab = selected;
+    const panelTab = activePanelTab;
     // The panel tab is intentionally selected while a panel is open.
     if (selectedTab === panelTab) {
       if (this.#activeParentTab && !this.#activeParentTab.closing) {
@@ -2039,6 +2066,35 @@ export class SineWebPanels {
       this.#closePanel({ animate: false });
     }
   };
+
+  // Hand the window back to a real tab. Nothing more.
+  //
+  // An earlier version also opened the panel the backing belonged to, on the
+  // grounds that picking its site out of the address bar is someone asking for
+  // exactly that. It span, because the guard then mistook the panel's own
+  // selection for another stray backing (see #onTabSelect) and opened it
+  // again, forever. The browser crawled and no panel worked at all.
+  //
+  // Holding the invariant is the job; guessing intent is not worth a loop.
+  // Re-entrancy is blocked too, because correcting the selection is itself a
+  // selection change.
+  #takeSelectionOffPanelTab(tab) {
+    if (this.#correctingSelection) {
+      return;
+    }
+
+    const replacement = this.#firstOrdinaryTab();
+    if (!replacement || replacement === tab) {
+      return;
+    }
+
+    this.#correctingSelection = true;
+    try {
+      this.window.gBrowser.selectedTab = replacement;
+    } finally {
+      this.#correctingSelection = false;
+    }
+  }
 
   #onTabClose = event => {
     const tab = event.target;
@@ -2130,7 +2186,17 @@ export class SineWebPanels {
       return this.#activeParentTab;
     }
 
-    return null;
+    // Returning null here is what made every panel refuse to open once the
+    // window was sitting on a backing tab: #openSurface needs a parent, and
+    // without one it bails. Any ordinary tab will do as an anchor.
+    return this.#firstOrdinaryTab();
+  }
+
+  // A tab the window can actually show: not one of ours, not on its way out.
+  #firstOrdinaryTab() {
+    const gBrowser = this.window.gBrowser;
+    const tabs = gBrowser?.visibleTabs ?? gBrowser?.tabs ?? [];
+    return [...tabs].find(tab => tab && !tab.closing && !this.#isPanelTab(tab)) ?? null;
   }
 
   #isPanelTab(tab) {

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -766,6 +766,21 @@ class SineWebPanels {
     });
   }
 
+  // Promote wherever the panel is now to its configured home. Sites whose URL
+  // encodes an account or workspace (Proton's /u/N, for instance) use indexes
+  // that drift, so pinning the home by hand is guesswork — this lets the panel
+  // record the right one once it is actually there.
+  #setHomeToCurrent(item) {
+    const browser = this.#runtime?.getBrowser(item.id);
+    const spec = browser?.currentURI?.spec;
+    if (!spec || !normalizeWebPanelUrl(spec)) {
+      return;
+    }
+    this.#store.updatePanel(item.id, spec, item.name ?? null);
+    this.#store.forgetUrl(item.id);
+    this.#render();
+  }
+
   #updateNavState() {
     if (!this.#navBar) {
       return;
@@ -1269,6 +1284,7 @@ class SineWebPanels {
           ["Back", () => this.#navGoBack(), this.#activeId !== item.id],
           ["Forward", () => this.#navGoForward(), this.#activeId !== item.id],
           ["Home (reset)", () => this.#navGoHome(item)],
+          ["Set current page as home", () => this.#setHomeToCurrent(item), this.#activeId !== item.id],
           ["separator"],
           ["Open in New Tab", () => this.#openInNewTab(item.url)],
           ["Edit Web Panel", () => this.#openEditor({ mode: "edit", item, anchor: this.#findItemElement(item.id) })],

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -1569,14 +1569,18 @@ export class SineWebPanels {
       placeholder: "https://calendar.google.com",
       "aria-label": "Web Panel URL",
     });
-    // Optional name: panels otherwise fall back to their hostname, and nobody
-    // searches for "mail.google.com" when they mean Gmail.
+    // The name lives in Edit only. Adding a panel is one field and one
+    // click; naming is for the exception — two accounts on the same site
+    // auto-name identically — and right-clicking the icon is the moment
+    // someone knows they need it. (Tom's call, 2026-09-09.)
     const nameInput = this.#el("input", {
       id: "sine-web-panels-name-input",
       type: "text",
       placeholder: "Name (optional)",
       "aria-label": "Web Panel name",
+      hidden: "true",
     });
+    nameInput.hidden = true;
     const error = this.#el("div", {
       id: "sine-web-panels-editor-error",
       role: "alert",
@@ -1584,7 +1588,7 @@ export class SineWebPanels {
     });
     const submit = this.#button({
       id: "sine-web-panels-editor-submit",
-      label: "+ Add",
+      label: "Add",
       className: "sine-web-panels-ghost-button",
     });
     submit.type = "submit";
@@ -1612,9 +1616,11 @@ export class SineWebPanels {
     const error = this.#editor.querySelector('[role="alert"]');
     this.#closeMenu();
     this.#editorState = { mode, itemId: item?.id ?? null, insertIndex };
+    this.#editor.setAttribute("mode", mode);
     input.value = item?.url ?? this.#currentTabUrl() ?? "";
     nameInput.value = item?.name ?? "";
-    submit.textContent = mode === "edit" ? "Save" : "+ Add";
+    nameInput.hidden = mode !== "edit";
+    submit.textContent = mode === "edit" ? "Save" : "Add";
     submit.disabled = !input.value.trim();
     error.hidden = true;
     this.#editor.hidden = false;
@@ -1642,7 +1648,9 @@ export class SineWebPanels {
         this.#unloadPanel(updated.id);
       }
     } else {
-      this.#store.insert(this.#store.createPanel(url, nameInput.value), this.#editorState?.insertIndex ?? this.#items.length);
+      // No name on Add: the field is not shown there, and a stale value must
+      // not travel from an earlier Edit.
+      this.#store.insert(this.#store.createPanel(url, ""), this.#editorState?.insertIndex ?? this.#items.length);
     }
 
     this.#closeEditor();

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -478,10 +478,18 @@ class SineWebPanels {
     parentBrowser.docShellIsActive = true;
     panelBrowser.zenModeActive = true;
     panelBrowser.docShellIsActive = true;
-    if (this.window.gBrowser?.selectedTab === panelTab && parentTab) {
-      this.window.gBrowser.selectedTab = parentTab;
+    // Select the PANEL tab so WebExtensions resolve the panel's site:
+    // tabs.query({active:true}) is how password managers pick a context, and
+    // with the parent selected they offer credentials for the page behind the
+    // panel. Zen's async tab switcher will then move `deck-selected` onto the
+    // panel container and strip it from the parent, which would stop the parent
+    // painting and turn the overlay into a full replacement — so re-assert it.
+    if (this.window.gBrowser && this.window.gBrowser.selectedTab !== panelTab) {
+      this.window.gBrowser.selectedTab = panelTab;
     }
-    parentTab._visuallySelected = true;
+    if (parentTab) {
+      parentTab._visuallySelected = true;
+    }
     this.#surfaceState = {
       parentTab,
       panelTab,
@@ -491,7 +499,31 @@ class SineWebPanels {
       panelContainer,
       panelFrame,
     };
+    // must run after #surfaceState exists — it reads parentContainer from it
+    this.#keepParentPainted();
     return true;
+  }
+
+  // Zen's AsyncTabSwitcher owns `deck-selected` and runs across frames, so the
+  // class has to be re-applied after it settles, not just once synchronously.
+  #keepParentPainted() {
+    const apply = () => {
+      const parentContainer = this.#surfaceState?.parentContainer;
+      const parentBrowser = this.#surfaceState?.parentBrowser;
+      if (!parentContainer) {
+        return;
+      }
+      parentContainer.classList.add("deck-selected");
+      if (parentBrowser) {
+        parentBrowser.docShellIsActive = true;
+      }
+    };
+
+    apply();
+    this.window.requestAnimationFrame(() => {
+      apply();
+      this.window.requestAnimationFrame(apply);
+    });
   }
 
   #closeSurface({ selectParent = true } = {}) {
@@ -1046,8 +1078,12 @@ class SineWebPanels {
 
     const selectedTab = this.window.gBrowser?.selectedTab;
     const panelTab = this.#runtime?.get(this.#activeId)?.tab;
-    if (selectedTab === panelTab && this.#activeParentTab && !this.#activeParentTab.closing) {
-      this.window.gBrowser.selectedTab = this.#activeParentTab;
+    // The panel tab is intentionally selected while a panel is open.
+    if (selectedTab === panelTab) {
+      if (this.#activeParentTab && !this.#activeParentTab.closing) {
+        this.#activeParentTab._visuallySelected = true;
+      }
+      this.#keepParentPainted();
       return;
     }
 

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -1164,8 +1164,10 @@ class SineWebPanels {
   }
 
   #onWindowResize = () => {
+    // Clamp for DISPLAY only. Persisting here means a temporarily narrow
+    // window (a smaller screen, a tiled layout) permanently shrinks the width
+    // the user chose, with no way back once the window grows again.
     const width = this.#clampWidth(this.#store.width);
-    this.#store.width = width;
     this.#root.style.setProperty("--sine-web-panels-width", `${width}px`);
     this.document.documentElement.style.setProperty("--sine-web-panels-width", `${width}px`);
   };

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -99,6 +99,11 @@ class SineWebPanels {
   #resizeState = null;
   #resizeHovering = false;
   #dragState = null;
+  #navBar;
+  #tabsProgressListener;
+  #navBack;
+  #navForward;
+  #navHome;
 
   constructor(windowRef) {
     this.window = windowRef;
@@ -133,10 +138,16 @@ class SineWebPanels {
     if (this.#prefObserver) {
       Services.prefs.removeObserver(WebPanelsStore.prefs.enabled, this.#prefObserver);
     }
+    if (this.#tabsProgressListener) {
+      this.window.gBrowser?.removeTabsProgressListener?.(this.#tabsProgressListener);
+      this.#tabsProgressListener = null;
+    }
     this.#runtime?.destroy();
     this.#resetChromeLayout();
     this.#editor?.remove();
     this.#tabContextMenuItem?.remove();
+    this.#navBar?.remove();
+    this.#navBar = null;
     this.#resizer?.remove();
     this.#root?.remove();
     this.#activeId = null;
@@ -212,6 +223,24 @@ class SineWebPanels {
     this.window.addEventListener("resize", this.#onWindowResize, { signal });
     this.document.addEventListener("click", this.#onDocumentClick, { signal });
     this.document.addEventListener("keydown", this.#onKeyDown, { signal });
+    this.#tabsProgressListener = {
+      onLocationChange: (browser, _webProgress, _request, _location, _flags) => {
+        const tab = this.window.gBrowser?.getTabForBrowser?.(browser);
+        const panelId = tab?.getAttribute?.("sine-web-panel-id");
+        if (!panelId) {
+          return;
+        }
+
+        const item = this.#items.find(entry => entry.id === panelId);
+        if (item) {
+          this.#rememberLocation(item, browser);
+        }
+        if (panelId === this.#activeId) {
+          this.#updateNavState();
+        }
+      },
+    };
+    this.window.gBrowser?.addTabsProgressListener?.(this.#tabsProgressListener);
     this.window.gBrowser?.tabContainer?.addEventListener("TabSelect", this.#onTabSelect, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabClose", this.#onTabClose, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabAttrModified", this.#onTabAttrModified, { signal });
@@ -268,6 +297,10 @@ class SineWebPanels {
     }
 
     this.#closePanel({ animate: false });
+    if (this.#tabsProgressListener) {
+      this.window.gBrowser?.removeTabsProgressListener?.(this.#tabsProgressListener);
+      this.#tabsProgressListener = null;
+    }
     this.#runtime?.destroy();
     this.#runtime = new WebPanelsRuntime(this.window);
     this.#root.setAttribute("disabled", "true");
@@ -409,7 +442,7 @@ class SineWebPanels {
     }
     const switching = Boolean(this.#activeId && this.#activeId !== item.id);
     const parentTab = this.#currentVisibleTab() ?? this.#activeParentTab;
-    const panelTab = this.#runtime.ensurePanelTab(item, parentTab);
+    const panelTab = this.#runtime.ensurePanelTab(item, parentTab, this.#store.resolveUrl(item));
     if (!this.#openSurface(parentTab, panelTab)) {
       console.warn("[Web Panels] Could not attach managed panel tab to a Zen browser surface.");
       return;
@@ -482,7 +515,7 @@ class SineWebPanels {
     this.#closeSurface({ selectParent: false });
     parentContainer.classList.add("sine-web-panels-parent-background");
     panelContainer.classList.add("deck-selected", "sine-web-panels-overlay");
-    panelFrame.append(this.#resizer);
+    panelFrame.append(this.#buildNavBar(), this.#resizer);
     panelBrowser.setAttribute("sine-web-panel-selected", "true");
     parentBrowser.zenModeActive = true;
     parentBrowser.docShellIsActive = true;
@@ -644,6 +677,67 @@ class SineWebPanels {
     browser.addEventListener("load", update, { signal: this.#abortController.signal });
   }
 
+  // Only remember same-origin destinations: an auth bounce through a provider
+  // must never become the page the panel reopens on.
+  #rememberLocation(item, browser) {
+    const spec = browser?.currentURI?.spec;
+    if (!spec) {
+      return;
+    }
+
+    let sameOrigin = false;
+    try {
+      sameOrigin = new URL(spec).origin === new URL(item.url).origin;
+    } catch {
+      sameOrigin = false;
+    }
+
+    if (sameOrigin) {
+      this.#store.rememberUrl(item.id, spec);
+    }
+  }
+
+  #activePanelBrowser() {
+    return this.#runtime?.getBrowser(this.#activeId) ?? null;
+  }
+
+  #navGoBack() {
+    const browser = this.#activePanelBrowser();
+    if (browser?.canGoBack) {
+      browser.goBack();
+    }
+  }
+
+  #navGoForward() {
+    const browser = this.#activePanelBrowser();
+    if (browser?.canGoForward) {
+      browser.goForward();
+    }
+  }
+
+  // Home is also the reset: without clearing the memory the panel would drift
+  // straight back on the next restart.
+  #navGoHome(item = null) {
+    const target = item ?? this.#items.find(entry => entry.id === this.#activeId);
+    const browser = this.#runtime?.getBrowser(target?.id);
+    if (!target || !browser) {
+      return;
+    }
+    this.#store.forgetUrl(target.id);
+    browser.loadURI(Services.io.newURI(target.url), {
+      triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+    });
+  }
+
+  #updateNavState() {
+    if (!this.#navBar) {
+      return;
+    }
+    const browser = this.#activePanelBrowser();
+    this.#navBack.disabled = !browser?.canGoBack;
+    this.#navForward.disabled = !browser?.canGoForward;
+  }
+
   #syncUnreadFromTab(itemId) {
     const tab = this.#runtime?.get(itemId)?.tab;
     const browser = tab?.linkedBrowser;
@@ -685,6 +779,45 @@ class SineWebPanels {
       icon.removeAttribute("src");
       icon.setAttribute("fallback", "true");
     });
+  }
+
+  // A slim bar pinned to the top of the panel. It stays out of the way until
+  // the panel is hovered (see .sine-web-panels-nav in the stylesheet), so it
+  // costs no space while reading.
+  #buildNavBar() {
+    if (this.#navBar) {
+      this.#updateNavState();
+      return this.#navBar;
+    }
+
+    const bar = this.#el("div", {
+      class: "sine-web-panels-nav",
+      role: "toolbar",
+      "aria-label": "Web panel navigation",
+    });
+
+    const mk = (name, label, handler) => {
+      const button = this.#button({
+        className: `sine-web-panels-nav-button sine-web-panels-nav-${name}`,
+        title: label,
+      });
+      button.setAttribute("aria-label", label);
+      button.addEventListener("click", event => {
+        event.stopPropagation();
+        handler();
+        this.#updateNavState();
+      }, { signal: this.#abortController.signal });
+      return button;
+    };
+
+    this.#navBack = mk("back", "Back", () => this.#navGoBack());
+    this.#navForward = mk("forward", "Forward", () => this.#navGoForward());
+    this.#navHome = mk("home", "Home (reset this panel)", () => this.#navGoHome());
+
+    bar.append(this.#navBack, this.#navForward, this.#navHome);
+    this.#navBar = bar;
+    this.#updateNavState();
+    return bar;
   }
 
   #buildEditor() {
@@ -794,6 +927,10 @@ class SineWebPanels {
     const index = this.#items.findIndex(entry => entry.id === item.id);
     const actions = isPanel(item)
       ? [
+          ["Back", () => this.#navGoBack(), this.#activeId !== item.id],
+          ["Forward", () => this.#navGoForward(), this.#activeId !== item.id],
+          ["Home (reset)", () => this.#navGoHome(item)],
+          ["separator"],
           ["Open in New Tab", () => this.#openInNewTab(item.url)],
           ["Edit Web Panel", () => this.#openEditor({ mode: "edit", item, anchor: this.#findItemElement(item.id) })],
           ["Move Up", () => this.#moveItem(item.id, index - 1), index <= 0],
@@ -858,6 +995,7 @@ class SineWebPanels {
 
   #deleteItem(id) {
     this.#unloadPanel(id);
+    this.#store.forgetUrl(id);
     this.#store.remove(id);
     this.#unreadCounts.delete(id);
     this.#render();

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -77,6 +77,12 @@ const EDITOR_ID = "sine-web-panels-editor";
 const TAB_MENU_ITEM_ID = "sine-web-panels-tab-context-add";
 const RESIZER_ID = "sine-web-panels-resizer";
 const FINDER_ID = "sine-web-panels-finder";
+const TOGGLE_ID = "sine-web-panels-toggle";
+const EDGE_ID = "sine-web-panels-edge";
+
+// How long the peeked rail waits after the pointer leaves before sliding back
+// out. Long enough to cross the gap to a panel button without chasing it.
+const PEEK_OUT_DELAY = 320;
 
 // Firefox stamps the chrome root when the window goes fullscreen: `inFullscreen`
 // for either flavour (F11 or a page/video calling requestFullscreen), and
@@ -138,6 +144,11 @@ class SineWebPanels {
   #finderList;
   #finderIndex = 0;
   #tabsProgressListener;
+  #toggle;
+  #edge;
+  #collapsed = false;
+  #peeking = false;
+  #peekTimer = null;
   #fullscreen = false;
   #fullscreenObserver;
   #restoreAfterFullscreen = null;
@@ -177,6 +188,10 @@ class SineWebPanels {
     }
     this.#setResizeHover(false);
     this.#closeSurface({ selectParent: false });
+    if (this.#peekTimer) {
+      this.window.clearTimeout(this.#peekTimer);
+      this.#peekTimer = null;
+    }
     if (this.#prefObserver) {
       Services.prefs.removeObserver(WebPanelsStore.prefs.enabled, this.#prefObserver);
     }
@@ -232,6 +247,10 @@ class SineWebPanels {
       "aria-label": "Web Panels",
     });
     this.#list = this.#el("div", { id: LIST_ID });
+    this.#toggle = this.#button({
+      id: TOGGLE_ID,
+      className: "sine-web-panels-toggle",
+    });
     const addButton = this.#button({
       id: ADD_BUTTON_ID,
       label: "",
@@ -239,13 +258,19 @@ class SineWebPanels {
       className: "sine-web-panels-add-button",
     });
     addButton.setAttribute("aria-label", "New Web Panel");
-    this.#rail.append(this.#list, addButton);
+    this.#rail.append(this.#toggle, this.#list, addButton);
+
+    // The strip the pointer has to reach to bring a collapsed rail back. It is
+    // an element rather than a pointermove test on the window because chrome
+    // never sees pointer moves over remote content — only chrome DOM stacked
+    // above the content browser does.
+    this.#edge = this.#el("div", { id: EDGE_ID, hidden: "true" });
 
     this.#editor = this.#buildEditor();
     this.#menu = this.#el("div", { id: MENU_ID, hidden: "true", role: "menu" });
 
     this.#finder = this.#buildFinder();
-    this.#root.append(this.#backdrop, this.#rail, this.#menu, this.#finder);
+    this.#root.append(this.#backdrop, this.#edge, this.#rail, this.#menu, this.#finder);
     this.#browserChrome.append(this.#root, this.#resizer);
     (this.document.getElementById("mainPopupSet") ?? this.#browserChrome).append(this.#editor);
     this.#mountTabContextMenuItem();
@@ -261,6 +286,14 @@ class SineWebPanels {
         this.#closePanel();
       }
     }, { signal });
+    this.#toggle.addEventListener("click", event => {
+      event.stopPropagation();
+      this.#setCollapsed(!this.#collapsed);
+    }, { signal });
+    this.#edge.addEventListener("pointerenter", () => this.#setPeeking(true), { signal });
+    this.#edge.addEventListener("pointerleave", () => this.#schedulePeekOut(), { signal });
+    this.#rail.addEventListener("pointerenter", () => this.#cancelPeekTimer(), { signal });
+    this.#rail.addEventListener("pointerleave", () => this.#schedulePeekOut(), { signal });
     this.#rail.addEventListener("contextmenu", this.#onRailContextMenu, { signal });
     this.window.addEventListener("pointerdown", this.#onWindowPointerDown, { signal, capture: true });
     this.window.addEventListener("pointermove", this.#onPointerMove, { signal });
@@ -290,6 +323,7 @@ class SineWebPanels {
     this.window.gBrowser?.tabContainer?.addEventListener("TabClose", this.#onTabClose, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabAttrModified", this.#onTabAttrModified, { signal });
     this.#observeFullscreen();
+    this.#applyCollapsedState(this.#store.collapsed);
     this.#render();
 
   }
@@ -323,11 +357,17 @@ class SineWebPanels {
   #observePrefs() {
     this.#prefObserver = {
       observe: (_subject, topic, prefName) => {
-        if (topic === "nsPref:changed" && prefName === WebPanelsStore.prefs.enabled) {
+        if (topic !== "nsPref:changed") {
+          return;
+        }
+        if (prefName === WebPanelsStore.prefs.enabled) {
           this.#applyEnabledState();
         }
       },
     };
+    // Deliberately NOT observing `collapsed`: it is per-window state that is
+    // merely persisted, so hiding the rail in one window must not travel to
+    // the others.
     Services.prefs.addObserver(WebPanelsStore.prefs.enabled, this.#prefObserver);
   }
 
@@ -355,7 +395,15 @@ class SineWebPanels {
   }
 
   #syncChromeLayout() {
-    if (!this.#browserChrome || !this.#root || !this.#store.enabled || this.#fullscreen) {
+    if (!this.#browserChrome || !this.#root || !this.#store.enabled) {
+      return;
+    }
+
+    // Fullscreen belongs to the page, and a collapsed rail has no strip of
+    // window to reserve. Releasing here rather than only at the transition
+    // means every caller re-asserts the right layout.
+    if (this.#fullscreen || this.#collapsed) {
+      this.#releaseChromeLayout();
       return;
     }
 
@@ -395,6 +443,109 @@ class SineWebPanels {
     this.#contentContainer?.style.removeProperty("margin-inline-start");
     this.#contentContainer?.style.removeProperty("margin-inline-end");
     this.#contentContainer = null;
+  }
+
+  // --------------------------------------------------------------------------
+  // Collapse / peek
+  //
+  // Collapsed, the rail slides out and hands its reserved strip back to the
+  // content. It comes in again as an OVERLAY while the pointer rests at that
+  // window edge, so peeking never moves the page underneath.
+  // --------------------------------------------------------------------------
+
+  #setCollapsed(collapsed) {
+    const next = Boolean(collapsed);
+    if (next === this.#collapsed) {
+      return;
+    }
+
+    // Per window. The pref is written to remember how the rail was last left —
+    // it seeds the next window and the next session — but nothing observes it,
+    // so hiding the rail here leaves every other window alone.
+    this.#store.collapsed = next;
+    this.#applyCollapsedState(next);
+  }
+
+  #applyCollapsedState(collapsed) {
+    const changed = collapsed !== this.#collapsed;
+    this.#collapsed = collapsed;
+    if (!this.#root) {
+      return;
+    }
+
+    if (collapsed && changed) {
+      // An open panel would keep covering the very edge the rail hides behind,
+      // and a panel anchored to a rail that is not there reads as a bug.
+      this.#closePanel({ animate: false });
+      this.#closeMenu();
+      this.#closeEditor();
+      this.#closeFinder();
+    }
+
+    this.#setPeeking(false);
+    this.#root.toggleAttribute("collapsed", collapsed);
+    this.#edge.hidden = !collapsed;
+    this.#updateToggleLabel();
+    this.#syncChromeLayout();
+  }
+
+  #updateToggleLabel() {
+    if (!this.#toggle) {
+      return;
+    }
+
+    const label = this.#collapsed ? "Show the panel rail" : "Hide the panel rail";
+    this.#toggle.title = label;
+    this.#toggle.setAttribute("aria-label", label);
+    this.#toggle.setAttribute("aria-pressed", String(!this.#collapsed));
+  }
+
+  #setPeeking(peeking) {
+    this.#cancelPeekTimer();
+    const next = Boolean(peeking) && this.#collapsed;
+    if (next === this.#peeking) {
+      return;
+    }
+
+    this.#peeking = next;
+    this.#root?.toggleAttribute("peeking", next);
+  }
+
+  #schedulePeekOut() {
+    if (!this.#peeking) {
+      return;
+    }
+
+    this.#cancelPeekTimer();
+    this.#peekTimer = this.window.setTimeout(() => {
+      this.#peekTimer = null;
+      if (this.#peekHeld()) {
+        this.#schedulePeekOut();
+        return;
+      }
+      this.#setPeeking(false);
+    }, PEEK_OUT_DELAY);
+  }
+
+  #cancelPeekTimer() {
+    if (this.#peekTimer) {
+      this.window.clearTimeout(this.#peekTimer);
+      this.#peekTimer = null;
+    }
+  }
+
+  // Things the rail owns but that live outside it: sliding away under an open
+  // menu, mid-drag, or while the panel it opened covers the edge would leave
+  // the user with no way back to it.
+  #peekHeld() {
+    return Boolean(
+      this.#activeId ||
+      this.#resizeState ||
+      this.#dragState ||
+      (this.#menu && !this.#menu.hidden) ||
+      (this.#finder && !this.#finder.hidden) ||
+      this.#editorState
+    );
   }
 
   // The rail is browser chrome, so it has no business sitting on top of a
@@ -1428,6 +1579,8 @@ class SineWebPanels {
         this.#render();
       }],
       ["New Web Panel", () => this.#openEditor({ mode: "add", anchor: this.#rail, insertIndex: this.#railInsertIndex })],
+      ["separator"],
+      ["Hide the rail", () => this.#setCollapsed(true)],
     ]);
   };
 
@@ -1677,6 +1830,15 @@ class SineWebPanels {
       this.#closeMenu();
       this.#closeEditor();
       this.#closePanel();
+      return;
+    }
+
+    // Same modifier as the panel numbers, on B — hide or show the rail, the
+    // binding editors use for their own sidebar.
+    if (shortcutMatches(event, this.#store.shortcutModifier) && event.code === "KeyB") {
+      event.preventDefault();
+      event.stopPropagation();
+      this.#setCollapsed(!this.#collapsed);
       return;
     }
 

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -11,6 +11,32 @@ import {
 // Digit -> panel position. 1..9 map to the first nine panels, 0 to the tenth,
 // matching how browsers number tabs. event.code is used rather than event.key
 // because on several layouts Ctrl+Alt behaves as AltGr and rewrites event.key.
+// Page titles are mostly noise plus the site name at the end:
+//   "Inbox (1,140) - diego88aku@gmail.com - Gmail"  -> "Gmail"
+//   "(2) WhatsApp"                                  -> "WhatsApp"
+// Take the trailing segment after a separator, minus any unread-count prefix,
+// so panels name themselves without anyone typing anything.
+function prettyPanelName(rawTitle) {
+  const stripped = String(rawTitle ?? "")
+    .replace(/^\s*[([]\d{1,4}[)\]]\s*/, "")
+    .trim();
+  if (!stripped) {
+    return null;
+  }
+
+  const parts = stripped
+    .split(/\s+[-–—|·:]\s+/)
+    .map(part => part.trim())
+    .filter(Boolean);
+  if (!parts.length) {
+    return stripped;
+  }
+
+  const last = parts[parts.length - 1];
+  // A long trailing segment is a headline, not a site name.
+  return last.length <= 40 ? last : parts[0];
+}
+
 function panelIndexFromEvent(event) {
   const match = /^(?:Digit|Numpad)([0-9])$/.exec(event.code || "");
   const digit = match ? Number(match[1]) : NaN;
@@ -50,6 +76,7 @@ const MENU_ID = "sine-web-panels-menu";
 const EDITOR_ID = "sine-web-panels-editor";
 const TAB_MENU_ITEM_ID = "sine-web-panels-tab-context-add";
 const RESIZER_ID = "sine-web-panels-resizer";
+const FINDER_ID = "sine-web-panels-finder";
 
 function isPanel(item) {
   return item?.type === PANEL_TYPE;
@@ -100,6 +127,10 @@ class SineWebPanels {
   #resizeHovering = false;
   #dragState = null;
   #navBar;
+  #finder;
+  #finderInput;
+  #finderList;
+  #finderIndex = 0;
   #tabsProgressListener;
   #navBack;
   #navForward;
@@ -146,6 +177,8 @@ class SineWebPanels {
     this.#resetChromeLayout();
     this.#editor?.remove();
     this.#tabContextMenuItem?.remove();
+    this.#finder?.remove();
+    this.#finder = null;
     this.#navBar?.remove();
     this.#navBar = null;
     this.#resizer?.remove();
@@ -200,7 +233,8 @@ class SineWebPanels {
     this.#editor = this.#buildEditor();
     this.#menu = this.#el("div", { id: MENU_ID, hidden: "true", role: "menu" });
 
-    this.#root.append(this.#backdrop, this.#rail, this.#menu);
+    this.#finder = this.#buildFinder();
+    this.#root.append(this.#backdrop, this.#rail, this.#menu, this.#finder);
     this.#browserChrome.append(this.#root, this.#resizer);
     (this.document.getElementById("mainPopupSet") ?? this.#browserChrome).append(this.#editor);
     this.#mountTabContextMenuItem();
@@ -245,6 +279,7 @@ class SineWebPanels {
     this.window.gBrowser?.tabContainer?.addEventListener("TabClose", this.#onTabClose, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabAttrModified", this.#onTabAttrModified, { signal });
     this.#render();
+
   }
 
   #mountTabContextMenuItem() {
@@ -376,7 +411,7 @@ class SineWebPanels {
   #renderPanelButton(item, index) {
     const button = this.#button({
       className: "sine-web-panels-item sine-web-panels-panel-button",
-      title: item.title || item.url,
+      title: this.#panelName(item),
     });
     button.dataset.itemId = item.id;
     button.dataset.index = String(index);
@@ -458,6 +493,7 @@ class SineWebPanels {
     this.#root.removeAttribute("closing");
     this.#root.setAttribute("active", item.id);
     this.#bindBrowserTitle(item, panelTab.linkedBrowser);
+    this.#store.rememberTitle(item.id, panelTab.label);
     this.#syncUnreadFromTab(item.id);
     this.#render();
     this.window.setTimeout(() => {
@@ -671,6 +707,7 @@ class SineWebPanels {
     browser.setAttribute("sine-web-panels-title-bound", item.id);
     const update = () => {
       this.#syncUnreadFromTab(item.id);
+      this.#store.rememberTitle(item.id, this.#runtime?.get(item.id)?.tab?.label);
       this.#render();
     };
     browser.addEventListener("DOMTitleChanged", update, { signal: this.#abortController.signal });
@@ -820,6 +857,297 @@ class SineWebPanels {
     return bar;
   }
 
+  // A filter over the rail: type to narrow the panel list, Enter opens the
+  // highlighted one. Self-contained — it reads the same #items the rail draws,
+  // so panels never opened this session are searchable too.
+  #buildFinder() {
+    const finder = this.#el("div", { id: FINDER_ID, hidden: "true", role: "dialog" });
+    const input = this.#el("input", {
+      type: "text",
+      placeholder: "Search web panels…",
+      "aria-label": "Search web panels",
+    });
+    const list = this.#el("div", { class: "sine-web-panels-finder-list", role: "listbox" });
+
+    input.addEventListener("input", () => this.#renderFinder(), {
+      signal: this.#abortController.signal,
+    });
+    finder.addEventListener("keydown", event => this.#onFinderKeyDown(event), {
+      signal: this.#abortController.signal,
+      capture: true,
+    });
+
+    finder.append(input, list);
+    this.#finderInput = input;
+    this.#finderList = list;
+    return finder;
+  }
+
+  // Everything the finder can act on, grouped: web panels first, then the
+  // tabs of each space. Panels come from #items (so panels never opened this
+  // session are included); tabs come from gBrowser, minus the hidden tabs the
+  // mod owns.
+  #finderGroups() {
+    const query = (this.#finderInput?.value ?? "").trim().toLowerCase();
+    const hit = (...fields) =>
+      !query || fields.some(f => (f ?? "").toLowerCase().includes(query));
+
+    const groups = [];
+
+    const titles = this.#store.lastTitles;
+    const panels = this.#items
+      .filter(isPanel)
+      .filter(item =>
+        hit(
+          this.#panelName(item),
+          item.name,
+          item.title,
+          item.url,
+          titles[item.id],
+          this.#runtime?.get(item.id)?.tab?.label
+        )
+      )
+      .map(item => ({
+        kind: "panel",
+        item,
+        folder: item.title,
+        label: this.#panelName(item),
+      }));
+    if (panels.length) {
+      groups.push({ id: "panels", title: "Web panels", icon: "◧", entries: panels });
+    }
+
+    // tabs, bucketed by the space they live in
+    const spaces = new Map();
+    const seen = new Set();
+    for (const tab of this.#allTabs()) {
+      if (this.#isPanelTab(tab) || tab.closing) {
+        continue;
+      }
+      const label = tab.label ?? "";
+      const url = tab.linkedBrowser?.currentURI?.spec ?? "";
+      if (!hit(label, url)) {
+        continue;
+      }
+      const spaceId = tab.getAttribute("zen-workspace-id") || "";
+      // Only collapse rows that genuinely point at the same page. Lazily
+      // restored tabs have no currentURI yet, and falling back to the title
+      // there merges distinct tabs whose titles happen to match — which is how
+      // a whole space's worth of results disappeared.
+      if (url) {
+        const dedupeKey = `${spaceId}|${url}`;
+        if (seen.has(dedupeKey)) {
+          continue;
+        }
+        seen.add(dedupeKey);
+      }
+      if (!spaces.has(spaceId)) {
+        spaces.set(spaceId, []);
+      }
+      const group = tab.group;
+      const folder = group?.isZenFolder ? group.label || null : null;
+      spaces.get(spaceId).push({ kind: "tab", tab, folder, label: label || url });
+    }
+
+    for (const [spaceId, entries] of spaces) {
+      const space = this.#spaceInfo(spaceId);
+      groups.push({ id: `space:${spaceId}`, title: space.name, icon: space.icon, entries });
+    }
+
+    // nothing matched: offer to open it instead of dead-ending
+    if (!groups.length && query) {
+      groups.push({
+        id: "open",
+        title: "Open",
+        icon: "＋",
+        entries: [{ kind: "open", query, label: this.#openLabel(query) }],
+      });
+    }
+
+    return groups;
+  }
+
+  // gBrowser.tabs only holds the spaces that have actually been visited — Zen
+  // materialises a space's tabs on first switch. _allStoredTabs carries every
+  // tab, which is what makes unvisited spaces searchable at all.
+  #allTabs() {
+    const stored = this.window.gZenWorkspaces?._allStoredTabs;
+    const live = [...(this.window.gBrowser?.tabs ?? [])];
+    if (!Array.isArray(stored) || !stored.length) {
+      return live;
+    }
+    return [...new Set([...stored, ...live])];
+  }
+
+  // Precedence: a name the user typed, then one derived from the page title
+  // (remembered across restarts), then the hostname we started with.
+  #panelName(item) {
+    if (item.name) {
+      return item.name;
+    }
+    const live = this.#runtime?.get(item.id)?.tab?.label;
+    const remembered = this.#store.lastTitles[item.id];
+    return prettyPanelName(live || remembered) || item.title || item.url;
+  }
+
+  #spaceInfo(spaceId) {
+    const fallback = { name: "Other tabs", icon: "▤" };
+    if (!spaceId) {
+      return fallback;
+    }
+    try {
+      // _workspaceCache IS the array of {uuid, name, icon, position, theme}.
+      const cache = this.window.gZenWorkspaces?._workspaceCache;
+      const all = Array.isArray(cache) ? cache : (cache?.workspaces ?? []);
+      const found = all.find(w => w.uuid === spaceId);
+      if (found) {
+        return { name: found.name || "Space", icon: found.icon || "▤" };
+      }
+    } catch {
+      // Zen internals move between versions; the fallback keeps the finder usable.
+    }
+    return fallback;
+  }
+
+  #openLabel(query) {
+    return normalizeWebPanelUrl(query) ? `Open ${query}` : `Search for “${query}”`;
+  }
+
+  #finderEntries() {
+    return this.#finderGroups().flatMap(group => group.entries);
+  }
+
+  #activateFinderEntry(entry) {
+    this.#closeFinder();
+    if (!entry) {
+      return;
+    }
+    if (entry.kind === "panel") {
+      this.#togglePanel(entry.item);
+      return;
+    }
+    if (entry.kind === "tab") {
+      this.#closePanel({ animate: false });
+      this.window.gBrowser.selectedTab = entry.tab;
+      return;
+    }
+    if (entry.kind === "open") {
+      const url = normalizeWebPanelUrl(entry.query);
+      if (url) {
+        this.#openInNewTab(url);
+      } else {
+        this.window.openTrustedLinkIn?.(
+          this.window.BrowserSearch?.searchURL?.(entry.query) ?? entry.query,
+          "tab"
+        );
+      }
+    }
+  }
+
+  #renderFinder() {
+    if (!this.#finderList) {
+      return;
+    }
+
+    const groups = this.#finderGroups();
+    const entries = groups.flatMap(group => group.entries);
+    this.#finderIndex = Math.max(0, Math.min(this.#finderIndex, entries.length - 1));
+    this.#finderList.replaceChildren();
+
+    let flat = 0;
+    for (const group of groups) {
+      const header = this.#el("div", { class: "sine-web-panels-finder-group" });
+      header.append(
+        this.#el("span", { class: "sine-web-panels-finder-group-icon" }, group.icon),
+        this.#el("span", { class: "sine-web-panels-finder-group-title" }, group.title)
+      );
+      this.#finderList.append(header);
+
+      for (const entry of group.entries) {
+        const index = flat++;
+        const row = this.#button({
+          className: `sine-web-panels-finder-row sine-web-panels-finder-${entry.kind}`,
+        });
+        // Space is the group header; the folder rides on the row so the full
+        // Space / Folder / tab path is visible without nesting the list.
+        if (entry.folder) {
+          row.append(this.#el("span", { class: "sine-web-panels-finder-folder" }, entry.folder));
+        }
+        row.append(this.#el("span", { class: "sine-web-panels-finder-label" }, entry.label));
+        row.setAttribute("role", "option");
+        if (index === this.#finderIndex) {
+          row.setAttribute("selected", "true");
+          this.window.requestAnimationFrame(() =>
+            row.scrollIntoView({ block: "nearest" })
+          );
+        }
+
+        // Panels keep their favicon; tabs reuse the one Zen already resolved;
+        // the open-new row gets the group glyph instead.
+        if (entry.kind === "panel") {
+          const icon = this.#el("img", { class: "sine-web-panels-favicon", alt: "", draggable: "false" });
+          this.#setFaviconSource(icon, entry.item.url, this.#runtime?.get(entry.item.id)?.tab?.getAttribute("image"));
+          row.prepend(icon);
+        } else if (entry.kind === "tab") {
+          const image = entry.tab.getAttribute("image");
+          if (image) {
+            const icon = this.#el("img", { class: "sine-web-panels-favicon", alt: "", draggable: "false", src: image });
+            row.prepend(icon);
+          }
+        }
+
+        row.addEventListener("click", event => {
+          event.stopPropagation();
+          this.#activateFinderEntry(entry);
+        }, { signal: this.#abortController.signal });
+        this.#finderList.append(row);
+      }
+    }
+  }
+
+  #onFinderKeyDown(event) {
+    const entries = this.#finderEntries();
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.#closeFinder();
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!entries.length) {
+        return;
+      }
+      const step = event.key === "ArrowDown" ? 1 : -1;
+      this.#finderIndex = (this.#finderIndex + step + entries.length) % entries.length;
+      this.#renderFinder();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      this.#activateFinderEntry(entries[this.#finderIndex]);
+    }
+  }
+
+  #openFinder() {
+    if (!this.#finder) {
+      return;
+    }
+    this.#closeMenu();
+    this.#closeEditor();
+    this.#finderIndex = 0;
+    this.#finderInput.value = "";
+    this.#finder.hidden = false;
+    this.#renderFinder();
+    this.window.requestAnimationFrame(() => this.#finderInput.focus());
+  }
+
+  #closeFinder() {
+    if (this.#finder) {
+      this.#finder.hidden = true;
+    }
+  }
+
   #buildEditor() {
     const editor = this.#xul("panel", {
       id: EDITOR_ID,
@@ -838,6 +1166,14 @@ class SineWebPanels {
       placeholder: "https://calendar.google.com",
       "aria-label": "Web Panel URL",
     });
+    // Optional name: panels otherwise fall back to their hostname, and nobody
+    // searches for "mail.google.com" when they mean Gmail.
+    const nameInput = this.#el("input", {
+      id: "sine-web-panels-name-input",
+      type: "text",
+      placeholder: "Name (optional)",
+      "aria-label": "Web Panel name",
+    });
     const error = this.#el("div", {
       id: "sine-web-panels-editor-error",
       role: "alert",
@@ -849,7 +1185,7 @@ class SineWebPanels {
       className: "sine-web-panels-ghost-button",
     });
     submit.type = "submit";
-    form.append(input, submit, error);
+    form.append(input, nameInput, submit, error);
     form.addEventListener("submit", event => {
       event.preventDefault();
       this.#saveEditor();
@@ -867,12 +1203,14 @@ class SineWebPanels {
   }
 
   #openEditor({ mode, item = null, anchor = null, insertIndex = this.#items.length }) {
-    const input = this.#editor.querySelector("input");
+    const input = this.#editor.querySelector("#sine-web-panels-url-input");
+    const nameInput = this.#editor.querySelector("#sine-web-panels-name-input");
     const submit = this.#editor.querySelector("button");
     const error = this.#editor.querySelector('[role="alert"]');
     this.#closeMenu();
     this.#editorState = { mode, itemId: item?.id ?? null, insertIndex };
     input.value = item?.url ?? this.#currentTabUrl() ?? "";
+    nameInput.value = item?.name ?? "";
     submit.textContent = mode === "edit" ? "Save" : "+ Add";
     submit.disabled = !input.value.trim();
     error.hidden = true;
@@ -885,7 +1223,8 @@ class SineWebPanels {
   }
 
   #saveEditor() {
-    const input = this.#editor.querySelector("input");
+    const input = this.#editor.querySelector("#sine-web-panels-url-input");
+    const nameInput = this.#editor.querySelector("#sine-web-panels-name-input");
     const error = this.#editor.querySelector('[role="alert"]');
     const url = normalizeWebPanelUrl(input.value);
     if (!url) {
@@ -895,12 +1234,12 @@ class SineWebPanels {
     }
 
     if (this.#editorState?.mode === "edit") {
-      const updated = this.#store.updatePanel(this.#editorState.itemId, url);
+      const updated = this.#store.updatePanel(this.#editorState.itemId, url, nameInput.value);
       if (updated) {
         this.#unloadPanel(updated.id);
       }
     } else {
-      this.#store.insert(this.#store.createPanel(url), this.#editorState?.insertIndex ?? this.#items.length);
+      this.#store.insert(this.#store.createPanel(url, nameInput.value), this.#editorState?.insertIndex ?? this.#items.length);
     }
 
     this.#closeEditor();
@@ -996,6 +1335,7 @@ class SineWebPanels {
   #deleteItem(id) {
     this.#unloadPanel(id);
     this.#store.forgetUrl(id);
+    this.#store.forgetTitle(id);
     this.#store.remove(id);
     this.#unreadCounts.delete(id);
     this.#render();
@@ -1195,9 +1535,25 @@ class SineWebPanels {
 
   #onKeyDown = event => {
     if (event.key === "Escape") {
+      // While the finder is open Escape belongs to it, not to the panel.
+      if (this.#finder && !this.#finder.hidden) {
+        this.#closeFinder();
+        return;
+      }
       this.#closeMenu();
       this.#closeEditor();
       this.#closePanel();
+      return;
+    }
+
+    // Same modifier as the panel numbers, on P — "find a panel".
+    if (
+      shortcutMatches(event, this.#store.shortcutModifier) &&
+      (event.code === "KeyD" || event.code === "KeyP")
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.#openFinder();
       return;
     }
 
@@ -1265,6 +1621,7 @@ class SineWebPanels {
     }
 
     this.#syncUnreadFromTab(panelId);
+    this.#store.rememberTitle(panelId, event.target.label);
     this.#render();
   };
 

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -8,6 +8,29 @@ import {
   parseWebPanelUnreadCount,
 } from "./web-panels-store.uc.mjs";
 
+// Digit -> panel position. 1..9 map to the first nine panels, 0 to the tenth,
+// matching how browsers number tabs. event.code is used rather than event.key
+// because on several layouts Ctrl+Alt behaves as AltGr and rewrites event.key.
+function panelIndexFromEvent(event) {
+  const match = /^(?:Digit|Numpad)([0-9])$/.exec(event.code || "");
+  const digit = match ? Number(match[1]) : NaN;
+  if (Number.isNaN(digit)) {
+    return -1;
+  }
+  return digit === 0 ? 9 : digit - 1;
+}
+
+function shortcutMatches(event, spec) {
+  if (!spec || spec === "disabled" || event.metaKey || event.repeat) {
+    return false;
+  }
+  return (
+    event.ctrlKey === spec.includes("ctrl") &&
+    event.altKey === spec.includes("alt") &&
+    event.shiftKey === spec.includes("shift")
+  );
+}
+
 const ROOT_ID = "sine-web-panels-root";
 const RAIL_ID = "sine-web-panels-rail";
 const LIST_ID = "sine-web-panels-list";
@@ -993,6 +1016,26 @@ class SineWebPanels {
       this.#closeMenu();
       this.#closeEditor();
       this.#closePanel();
+      return;
+    }
+
+    // Toggle the Nth panel on the rail. Separators are skipped, so the
+    // numbering follows the visible panel order rather than the raw item
+    // index. The modifier combination is configurable in the mod's settings.
+    if (!shortcutMatches(event, this.#store.shortcutModifier)) {
+      return;
+    }
+
+    const index = panelIndexFromEvent(event);
+    if (index < 0) {
+      return;
+    }
+
+    const target = this.#items.filter(isPanel)[index];
+    if (target) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.#togglePanel(target);
     }
   };
 

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -97,6 +97,7 @@ const FULLSCREEN_ATTRIBUTES = ["inFullscreen", "inDOMFullscreen"];
 // Zen stamps this on the chrome root when its sidebar sits on the right.
 const ZEN_SIDEBAR_SIDE_ATTRIBUTE = "zen-right-side";
 
+
 function isPanel(item) {
   return item?.type === PANEL_TYPE;
 }
@@ -1651,15 +1652,6 @@ class SineWebPanels {
         this.#render();
       }],
       ["New Web Panel", () => this.#openEditor({ mode: "add", anchor: this.#rail, insertIndex: this.#railInsertIndex })],
-      ["separator"],
-      ["Hide the rail", () => this.#setCollapsed(true)],
-      [
-        "Reset handle colour",
-        () => {
-          this.#store.resizerColor = "";
-        },
-        !this.#store.resizerColor,
-      ],
     ]);
   };
 

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -94,6 +94,9 @@ const PEEK_OUT_DELAY = 320;
 // rather than guessing at event names keeps this working across Zen versions.
 const FULLSCREEN_ATTRIBUTES = ["inFullscreen", "inDOMFullscreen"];
 
+// Fired once the session's windows and their tabs are back.
+const SESSION_RESTORED_TOPIC = "sessionstore-windows-restored";
+
 // Zen stamps this on the chrome root when its sidebar sits on the right.
 const ZEN_SIDEBAR_SIDE_ATTRIBUTE = "zen-right-side";
 
@@ -143,6 +146,7 @@ class SineWebPanels {
   #ignoreOutsideClicksUntil = 0;
   #abortController = new AbortController();
   #prefObserver;
+  #sessionRestoreObserver;
   #resizeState = null;
   #resizeHovering = false;
   #dragState = null;
@@ -177,6 +181,8 @@ class SineWebPanels {
     this.#runtime = new WebPanelsRuntime(this.window);
     this.#applyEnabledState();
     this.#observePrefs();
+    this.#adoptRestoredPanelTabs();
+    this.#observeSessionRestore();
   }
 
   destroyExistingRoot() {
@@ -202,6 +208,10 @@ class SineWebPanels {
     if (this.#peekTimer) {
       this.window.clearTimeout(this.#peekTimer);
       this.#peekTimer = null;
+    }
+    if (this.#sessionRestoreObserver) {
+      Services.obs.removeObserver(this.#sessionRestoreObserver, SESSION_RESTORED_TOPIC);
+      this.#sessionRestoreObserver = null;
     }
     if (this.#prefObserver) {
       Services.prefs.removeObserver(WebPanelsStore.prefs.enabled, this.#prefObserver);
@@ -366,6 +376,33 @@ class SineWebPanels {
       signal: this.#abortController.signal,
     });
     this.#tabContextMenuItem = menuItem;
+  }
+
+  // Panel tabs are ordinary tabs as far as session restore is concerned, so a
+  // restart hands them back — visible, unclaimed, and about to be duplicated by
+  // the first panel that opens. Claim them before that happens.
+  //
+  // Run twice on purpose. A cold start reaches here before restore has
+  // finished, so the observer catches it; a mod hot-loaded into a window that
+  // is already up has missed that notification entirely, so the call in init
+  // catches that. Both are idempotent.
+  #adoptRestoredPanelTabs() {
+    if (!this.#runtime || !this.#store.enabled) {
+      return;
+    }
+
+    const { adopted, swept } = this.#runtime.adoptRestoredTabs(this.#items);
+    if (adopted.length || swept.length) {
+      console.log(
+        `[Web Panels] Reclaimed ${adopted.length} restored panel tab(s), ` +
+          `removed ${swept.length} with no panel left to open them.`
+      );
+    }
+  }
+
+  #observeSessionRestore() {
+    this.#sessionRestoreObserver = { observe: () => this.#adoptRestoredPanelTabs() };
+    Services.obs.addObserver(this.#sessionRestoreObserver, SESSION_RESTORED_TOPIC);
   }
 
   #observePrefs() {

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -168,6 +168,7 @@ export class SineWebPanels {
   #restoreAfterFullscreen = null;
   #navBack;
   #navForward;
+  #navReload;
   #navHome;
 
   constructor(windowRef) {
@@ -1130,6 +1131,11 @@ export class SineWebPanels {
     }
   }
 
+  // Plain reload of wherever the panel is now; Home is the one that resets.
+  #navReloadPage() {
+    this.#activePanelBrowser()?.reload?.();
+  }
+
   // Home is also the reset: without clearing the memory the panel would drift
   // straight back on the next restart.
   #navGoHome(item = null) {
@@ -1220,10 +1226,13 @@ export class SineWebPanels {
       return this.#navBar;
     }
 
+    // Floats beside the panel's outer edge (see the CSS), a vertical stack of
+    // back / forward / home. Nothing here overlaps the panel's page.
     const bar = this.#el("div", {
       class: "sine-web-panels-nav",
       role: "toolbar",
       "aria-label": "Web panel navigation",
+      "aria-orientation": "vertical",
     });
 
     const mk = (name, label, handler) => {
@@ -1242,9 +1251,10 @@ export class SineWebPanels {
 
     this.#navBack = mk("back", "Back", () => this.#navGoBack());
     this.#navForward = mk("forward", "Forward", () => this.#navGoForward());
+    this.#navReload = mk("reload", "Reload", () => this.#navReloadPage());
     this.#navHome = mk("home", "Home (reset this panel)", () => this.#navGoHome());
 
-    bar.append(this.#navBack, this.#navForward, this.#navHome);
+    bar.append(this.#navBack, this.#navForward, this.#navReload, this.#navHome);
     this.#navBar = bar;
     this.#updateNavState();
     return bar;

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -7,6 +7,7 @@ import {
   clampWebPanelWidth,
   normalizeWebPanelUrl,
   normalizeResizerColor,
+  webPanelSideForSidebar,
   panelMaxWidthFromViewport,
   parseWebPanelUnreadCount,
 } from "./web-panels-store.uc.mjs";
@@ -93,6 +94,9 @@ const PEEK_OUT_DELAY = 320;
 // rather than guessing at event names keeps this working across Zen versions.
 const FULLSCREEN_ATTRIBUTES = ["inFullscreen", "inDOMFullscreen"];
 
+// Zen stamps this on the chrome root when its sidebar sits on the right.
+const ZEN_SIDEBAR_SIDE_ATTRIBUTE = "zen-right-side";
+
 function isPanel(item) {
   return item?.type === PANEL_TYPE;
 }
@@ -154,6 +158,7 @@ class SineWebPanels {
   #peekTimer = null;
   #fullscreen = false;
   #fullscreenObserver;
+  #sidebarSideObserver;
   #restoreAfterFullscreen = null;
   #navBack;
   #navForward;
@@ -185,6 +190,8 @@ class SineWebPanels {
     this.#abortController.abort();
     this.#fullscreenObserver?.disconnect();
     this.#fullscreenObserver = null;
+    this.#sidebarSideObserver?.disconnect();
+    this.#sidebarSideObserver = null;
     if (this.#closeTimer) {
       this.window.clearTimeout(this.#closeTimer);
       this.#closeTimer = null;
@@ -327,6 +334,7 @@ class SineWebPanels {
     this.window.gBrowser?.tabContainer?.addEventListener("TabClose", this.#onTabClose, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabAttrModified", this.#onTabAttrModified, { signal });
     this.#observeFullscreen();
+    this.#observeSidebarSide();
     this.#applyResizerColor();
     this.#applyCollapsedState(this.#store.collapsed);
     this.#render();
@@ -574,6 +582,42 @@ class SineWebPanels {
       (this.#finder && !this.#finder.hidden) ||
       this.#editorState
     );
+  }
+
+  // The rail takes whichever side Zen's sidebar is not on, and Zen lets that be
+  // changed at runtime. Nothing re-read it: the side is applied at mount, in
+  // #render and in #syncChromeLayout, and none of those runs when the sidebar
+  // moves — so the two ended up stacked on the same side until the next
+  // restart. Same MutationObserver pattern as fullscreen, for the same reason:
+  // the attribute is what the layout actually keys off.
+  #observeSidebarSide() {
+    this.#sidebarSideObserver = new this.window.MutationObserver(() =>
+      this.#applyPlacementSide()
+    );
+    this.#sidebarSideObserver.observe(this.document.documentElement, {
+      attributes: true,
+      attributeFilter: [ZEN_SIDEBAR_SIDE_ATTRIBUTE],
+    });
+  }
+
+  #applyPlacementSide() {
+    if (!this.#root) {
+      return;
+    }
+
+    const side = this.#placementSide();
+    // The DOM is the cache — no point re-running the layout for an attribute
+    // that was rewritten with the value it already had.
+    if (this.#root.getAttribute("side") === side) {
+      return;
+    }
+
+    this.#root.setAttribute("side", side);
+    // Swaps the reserved margin from one side to the other; everything else —
+    // the rail, the panel overlay, the resizer — is keyed off the attributes
+    // this sets.
+    this.#syncChromeLayout();
+    this.#syncDisplayWidth();
   }
 
   // The rail is browser chrome, so it has no business sitting on top of a
@@ -2035,7 +2079,9 @@ class SineWebPanels {
   }
 
   #placementSide() {
-    return this.document.documentElement.getAttribute("zen-right-side") === "true" ? "left" : "right";
+    return webPanelSideForSidebar(
+      this.document.documentElement.getAttribute(ZEN_SIDEBAR_SIDE_ATTRIBUTE)
+    );
   }
 
   #currentTabUrl() {

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -20,12 +20,22 @@ function panelIndexFromEvent(event) {
   return digit === 0 ? 9 : digit - 1;
 }
 
+// The accelerator is Cmd on macOS and Ctrl everywhere else, so the two flags
+// swap roles by platform. Whichever one is NOT the accelerator must be unheld,
+// otherwise Ctrl+Cmd+1 would also fire on macOS.
+const IS_MACOS = Services.appinfo.OS === "Darwin";
+
 function shortcutMatches(event, spec) {
-  if (!spec || spec === "disabled" || event.metaKey || event.repeat) {
+  if (!spec || spec === "disabled" || event.repeat) {
     return false;
   }
+
+  const accelHeld = IS_MACOS ? event.metaKey : event.ctrlKey;
+  const nonAccelHeld = IS_MACOS ? event.ctrlKey : event.metaKey;
+
   return (
-    event.ctrlKey === spec.includes("ctrl") &&
+    !nonAccelHeld &&
+    accelHeld === spec.includes("accel") &&
     event.altKey === spec.includes("alt") &&
     event.shiftKey === spec.includes("shift")
   );

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -4,7 +4,9 @@ import {
   PANEL_TYPE,
   SEPARATOR_TYPE,
   WebPanelsStore,
+  clampWebPanelWidth,
   normalizeWebPanelUrl,
+  panelMaxWidthFromViewport,
   parseWebPanelUnreadCount,
 } from "./web-panels-store.uc.mjs";
 
@@ -229,8 +231,7 @@ class SineWebPanels {
       id: ROOT_ID,
       side: this.#placementSide(),
     });
-    this.#root.style.setProperty("--sine-web-panels-width", `${this.#store.width}px`);
-    this.document.documentElement.style.setProperty("--sine-web-panels-width", `${this.#store.width}px`);
+    this.#syncDisplayWidth();
 
     this.#backdrop = this.#el("div", { id: BACKDROP_ID, hidden: "true" });
     this.#resizer = this.#el("div", {
@@ -487,6 +488,7 @@ class SineWebPanels {
     this.#edge.hidden = !collapsed;
     this.#updateToggleLabel();
     this.#syncChromeLayout();
+    this.#syncDisplayWidth();
   }
 
   #updateToggleLabel() {
@@ -1778,19 +1780,57 @@ class SineWebPanels {
   }
 
   #clampWidth(width) {
-    const railRect = this.#rail.getBoundingClientRect();
-    const gap = Number.parseFloat(this.window.getComputedStyle(this.#root).getPropertyValue("--sine-web-panels-gap")) || 8;
-    const max = Math.max(MIN_PANEL_WIDTH, this.window.innerWidth - railRect.width - gap * 3);
-    return Math.min(max, Math.max(MIN_PANEL_WIDTH, Math.round(width)));
+    const maxWidth = this.#panelMaxWidth();
+    if (maxWidth === null) {
+      // Unmeasurable. Apply the floor and nothing else — inventing a maximum
+      // is what put the panel over Zen's sidebar in the first place.
+      return Math.max(MIN_PANEL_WIDTH, Math.round(Number(width) || MIN_PANEL_WIDTH));
+    }
+
+    return clampWebPanelWidth(width, maxWidth);
   }
 
-  #onWindowResize = () => {
-    // Clamp for DISPLAY only. Persisting here means a temporarily narrow
-    // window (a smaller screen, a tiled layout) permanently shrinks the width
-    // the user chose, with no way back once the window grows again.
+  // How wide the panel may get, measured from the content container rather
+  // than from window.innerWidth — innerWidth is the whole chrome window and
+  // knows nothing about the sidebar Zen paints inside it.
+  //
+  // Deliberately NOT measured from the selected tab's browser: this mod
+  // selects the hidden PANEL tab while a panel is open, so that browser is the
+  // panel itself and the measurement would be reading back its own output. The
+  // content container is the box #syncChromeLayout already reserves against,
+  // it is laid out with the chrome rather than with a tab, and it is the same
+  // element whichever tab happens to be selected.
+  #panelMaxWidth() {
+    let rect = null;
+    try {
+      rect = this.#findContentContainer()?.getBoundingClientRect?.() ?? null;
+    } catch (error) {
+      console.error("[Web Panels] Could not measure the page viewport.", error);
+    }
+
+    return panelMaxWidthFromViewport(rect, {
+      top: 0,
+      left: 0,
+      width: this.document.documentElement.clientWidth || this.window.innerWidth,
+      height: this.document.documentElement.clientHeight || this.window.innerHeight,
+    });
+  }
+
+  // Clamp for DISPLAY only. Persisting here means a temporarily narrow window
+  // (a smaller screen, a tiled layout) permanently shrinks the width the user
+  // chose, with no way back once the window grows again.
+  #syncDisplayWidth() {
+    if (!this.#root) {
+      return;
+    }
+
     const width = this.#clampWidth(this.#store.width);
     this.#root.style.setProperty("--sine-web-panels-width", `${width}px`);
     this.document.documentElement.style.setProperty("--sine-web-panels-width", `${width}px`);
+  }
+
+  #onWindowResize = () => {
+    this.#syncDisplayWidth();
   };
 
   #onDocumentClick = event => {

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -78,6 +78,12 @@ const TAB_MENU_ITEM_ID = "sine-web-panels-tab-context-add";
 const RESIZER_ID = "sine-web-panels-resizer";
 const FINDER_ID = "sine-web-panels-finder";
 
+// Firefox stamps the chrome root when the window goes fullscreen: `inFullscreen`
+// for either flavour (F11 or a page/video calling requestFullscreen), and
+// `inDOMFullscreen` only for the content-driven one. Watching the attributes
+// rather than guessing at event names keeps this working across Zen versions.
+const FULLSCREEN_ATTRIBUTES = ["inFullscreen", "inDOMFullscreen"];
+
 function isPanel(item) {
   return item?.type === PANEL_TYPE;
 }
@@ -132,6 +138,9 @@ class SineWebPanels {
   #finderList;
   #finderIndex = 0;
   #tabsProgressListener;
+  #fullscreen = false;
+  #fullscreenObserver;
+  #restoreAfterFullscreen = null;
   #navBack;
   #navForward;
   #navHome;
@@ -160,6 +169,8 @@ class SineWebPanels {
 
   destroy() {
     this.#abortController.abort();
+    this.#fullscreenObserver?.disconnect();
+    this.#fullscreenObserver = null;
     if (this.#closeTimer) {
       this.window.clearTimeout(this.#closeTimer);
       this.#closeTimer = null;
@@ -278,6 +289,7 @@ class SineWebPanels {
     this.window.gBrowser?.tabContainer?.addEventListener("TabSelect", this.#onTabSelect, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabClose", this.#onTabClose, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabAttrModified", this.#onTabAttrModified, { signal });
+    this.#observeFullscreen();
     this.#render();
 
   }
@@ -343,7 +355,7 @@ class SineWebPanels {
   }
 
   #syncChromeLayout() {
-    if (!this.#browserChrome || !this.#root || !this.#store.enabled) {
+    if (!this.#browserChrome || !this.#root || !this.#store.enabled || this.#fullscreen) {
       return;
     }
 
@@ -369,13 +381,110 @@ class SineWebPanels {
   }
 
   #resetChromeLayout() {
+    this.#releaseChromeLayout();
+    this.document?.documentElement?.style.removeProperty("--sine-web-panels-width");
+  }
+
+  // Give the reserved inline space back to the content without forgetting how
+  // wide the panel is. The margin is written inline with `!important`, so no
+  // stylesheet can override it — fullscreen has to take it off in script.
+  #releaseChromeLayout() {
     this.#browserChrome?.removeAttribute("sine-web-panels-side");
     this.document?.documentElement?.removeAttribute("sine-web-panels-side");
-    this.document?.documentElement?.style.removeProperty("--sine-web-panels-width");
     this.#browserChrome?.style.removeProperty("--sine-web-panels-reserved-inline-size");
     this.#contentContainer?.style.removeProperty("margin-inline-start");
     this.#contentContainer?.style.removeProperty("margin-inline-end");
     this.#contentContainer = null;
+  }
+
+  // The rail is browser chrome, so it has no business sitting on top of a
+  // fullscreen video — and neither has the strip of window it reserves.
+  #observeFullscreen() {
+    this.#fullscreenObserver = new this.window.MutationObserver(() =>
+      this.#syncFullscreenState()
+    );
+    this.#fullscreenObserver.observe(this.document.documentElement, {
+      attributes: true,
+      attributeFilter: FULLSCREEN_ATTRIBUTES,
+    });
+    // The attribute is the source of truth, but the chrome-only `fullscreen`
+    // event fires on the window for F11 too, and catches the transition a tick
+    // earlier. Both funnel into the same idempotent sync.
+    this.window.addEventListener("fullscreen", () => this.#syncFullscreenState(), {
+      signal: this.#abortController.signal,
+      capture: true,
+    });
+    // Sine can hot-load the mod into a window that is already fullscreen.
+    this.#syncFullscreenState();
+  }
+
+  #isFullscreen() {
+    const root = this.document?.documentElement;
+    return Boolean(
+      root?.hasAttribute("inDOMFullscreen") ||
+      root?.hasAttribute("inFullscreen") ||
+      this.window.fullScreen
+    );
+  }
+
+  #syncFullscreenState() {
+    const fullscreen = this.#isFullscreen();
+    if (fullscreen === this.#fullscreen || !this.#root) {
+      return;
+    }
+    this.#fullscreen = fullscreen;
+
+    if (fullscreen) {
+      this.#closeMenu();
+      this.#closeEditor();
+      this.#closeFinder();
+
+      // A video fullscreened from inside a panel is the one case where the
+      // panel must survive: closing it would tear its browser out of the deck
+      // and cancel the fullscreen the user just asked for. Let it take the
+      // whole window instead (the rail still goes away).
+      if (this.#fullscreenTargetsActivePanel()) {
+        this.#restoreAfterFullscreen = null;
+        this.document.documentElement.setAttribute("sine-web-panels-panel-fullscreen", "true");
+      } else {
+        // Remember the open panel so leaving fullscreen puts the window back
+        // the way the user left it.
+        this.#restoreAfterFullscreen = this.#activeId;
+        this.#closePanel({ animate: false });
+      }
+
+      this.#root.setAttribute("fullscreen", "true");
+      this.#releaseChromeLayout();
+      return;
+    }
+
+    this.#root.removeAttribute("fullscreen");
+    this.document.documentElement.removeAttribute("sine-web-panels-panel-fullscreen");
+    this.#syncChromeLayout();
+
+    const restoreId = this.#restoreAfterFullscreen;
+    this.#restoreAfterFullscreen = null;
+    const item = restoreId ? this.#items.find(entry => entry.id === restoreId) : null;
+    if (item) {
+      this.#openPanel(item);
+    }
+  }
+
+  // Gecko sets the chrome document's fullscreenElement to the <browser> hosting
+  // the content that went fullscreen, before it stamps `inDOMFullscreen` — so
+  // by the time either signal reaches us this answer is already reliable.
+  #fullscreenTargetsActivePanel() {
+    const browser = this.#activePanelBrowser();
+    const element = this.document.fullscreenElement;
+    if (!browser || !element) {
+      return false;
+    }
+
+    return (
+      element === browser ||
+      element.contains?.(browser) === true ||
+      browser.contains?.(element) === true
+    );
   }
 
   #findContentContainer() {
@@ -470,6 +579,9 @@ class SineWebPanels {
   }
 
   #openPanel(item) {
+    if (this.#fullscreen) {
+      return;
+    }
     this.#closeEditor();
     if (this.#closeTimer) {
       this.window.clearTimeout(this.#closeTimer);
@@ -1550,6 +1662,12 @@ class SineWebPanels {
   };
 
   #onKeyDown = event => {
+    // Chrome is hidden in fullscreen, so the panel shortcuts stay dormant —
+    // otherwise Ctrl+Alt+1 would open an invisible panel over the video.
+    if (this.#fullscreen) {
+      return;
+    }
+
     if (event.key === "Escape") {
       // While the finder is open Escape belongs to it, not to the panel.
       if (this.#finder && !this.#finder.hidden) {

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -6,6 +6,7 @@ import {
   WebPanelsStore,
   clampWebPanelWidth,
   normalizeWebPanelUrl,
+  normalizeResizerColor,
   panelMaxWidthFromViewport,
   parseWebPanelUnreadCount,
 } from "./web-panels-store.uc.mjs";
@@ -196,6 +197,7 @@ class SineWebPanels {
     }
     if (this.#prefObserver) {
       Services.prefs.removeObserver(WebPanelsStore.prefs.enabled, this.#prefObserver);
+      Services.prefs.removeObserver(WebPanelsStore.prefs.resizerColor, this.#prefObserver);
     }
     if (this.#tabsProgressListener) {
       this.window.gBrowser?.removeTabsProgressListener?.(this.#tabsProgressListener);
@@ -203,6 +205,7 @@ class SineWebPanels {
     }
     this.#runtime?.destroy();
     this.#resetChromeLayout();
+    this.document?.documentElement?.style.removeProperty("--sine-web-panels-accent");
     this.#editor?.remove();
     this.#tabContextMenuItem?.remove();
     this.#finder?.remove();
@@ -324,6 +327,7 @@ class SineWebPanels {
     this.window.gBrowser?.tabContainer?.addEventListener("TabClose", this.#onTabClose, { signal });
     this.window.gBrowser?.tabContainer?.addEventListener("TabAttrModified", this.#onTabAttrModified, { signal });
     this.#observeFullscreen();
+    this.#applyResizerColor();
     this.#applyCollapsedState(this.#store.collapsed);
     this.#render();
 
@@ -363,6 +367,8 @@ class SineWebPanels {
         }
         if (prefName === WebPanelsStore.prefs.enabled) {
           this.#applyEnabledState();
+        } else if (prefName === WebPanelsStore.prefs.resizerColor) {
+          this.#applyResizerColor();
         }
       },
     };
@@ -370,6 +376,8 @@ class SineWebPanels {
     // merely persisted, so hiding the rail in one window must not travel to
     // the others.
     Services.prefs.addObserver(WebPanelsStore.prefs.enabled, this.#prefObserver);
+    // Unlike `collapsed`, this one is appearance and belongs to every window.
+    Services.prefs.addObserver(WebPanelsStore.prefs.resizerColor, this.#prefObserver);
   }
 
   #applyEnabledState() {
@@ -489,6 +497,24 @@ class SineWebPanels {
     this.#updateToggleLabel();
     this.#syncChromeLayout();
     this.#syncDisplayWidth();
+  }
+
+  // The handle sits outside #sine-web-panels-root, in the panel frame, so the
+  // override goes on the document root like --sine-web-panels-width does.
+  // Removing it lets the stylesheet's theme chain take over again, which is
+  // what makes "empty" a working reset rather than a blank colour.
+  #applyResizerColor() {
+    const color = this.#store.resizerColor;
+    const root = this.document?.documentElement;
+    if (!root) {
+      return;
+    }
+
+    if (color) {
+      root.style.setProperty("--sine-web-panels-accent", color);
+    } else {
+      root.style.removeProperty("--sine-web-panels-accent");
+    }
   }
 
   #updateToggleLabel() {
@@ -1583,6 +1609,13 @@ class SineWebPanels {
       ["New Web Panel", () => this.#openEditor({ mode: "add", anchor: this.#rail, insertIndex: this.#railInsertIndex })],
       ["separator"],
       ["Hide the rail", () => this.#setCollapsed(true)],
+      [
+        "Reset handle colour",
+        () => {
+          this.#store.resizerColor = "";
+        },
+        !this.#store.resizerColor,
+      ],
     ]);
   };
 

--- a/scripts/web-panels.uc.mjs
+++ b/scripts/web-panels.uc.mjs
@@ -53,7 +53,7 @@ function panelIndexFromEvent(event) {
 // The accelerator is Cmd on macOS and Ctrl everywhere else, so the two flags
 // swap roles by platform. Whichever one is NOT the accelerator must be unheld,
 // otherwise Ctrl+Cmd+1 would also fire on macOS.
-const IS_MACOS = Services.appinfo.OS === "Darwin";
+const IS_MACOS = globalThis.Services?.appinfo?.OS === "Darwin";
 
 function shortcutMatches(event, spec) {
   if (!spec || spec === "disabled" || event.repeat) {
@@ -121,7 +121,7 @@ function fallbackFaviconUrl(panelUrl) {
   }
 }
 
-class SineWebPanels {
+export class SineWebPanels {
   #store = new WebPanelsStore();
   #root;
   #rail;
@@ -2203,11 +2203,19 @@ class SineWebPanels {
   }
 }
 
-const instance = new SineWebPanels(window);
-instance.init();
+// Sine loads this into a chrome window, where `window` is a global and mounting
+// on import is the point. A test runner has no such window, and importing the
+// class there must not try to build a browser UI — so the bootstrap asks first
+// rather than assuming, which is what makes the controller testable at all.
+const chromeWindow = typeof window === "undefined" ? null : window;
 
-if (typeof window.addUnloadListener === "function") {
-  window.addUnloadListener(() => instance.destroy());
-} else {
-  window.addEventListener("unload", () => instance.destroy(), { once: true });
+if (chromeWindow?.document) {
+  const instance = new SineWebPanels(chromeWindow);
+  instance.init();
+
+  if (typeof chromeWindow.addUnloadListener === "function") {
+    chromeWindow.addUnloadListener(() => instance.destroy());
+  } else {
+    chromeWindow.addEventListener("unload", () => instance.destroy(), { once: true });
+  }
 }


### PR DESCRIPTION
Hi Tom,

This is the fork we have been discussing by email, rebased on your main so
it carries the licence. It is one PR rather than five because the pieces
were built on top of each other and no longer split cleanly. Take it as a
whole or tell me what to pull out.

Fixes #4 - the "ordinary tab URL blocks every panel" regression you found.
See the note at the bottom.

Two of your three UX points are still waiting on your answer, so this PR
does NOT yet contain them:

- the navigation header (gradient) is unchanged - say which shape you
  want and I will build it in this branch;
- the Add popup still has the name field - pending your view on moving it
  to Edit.

The third one, panel width, is in: your calculateWebPanelViewportGeometry
and clampWebPanelWidth, nearly verbatim.

WHAT IS IN HERE
---------------

Fixes
- Panel width bounded to the usable page area (your helpers).
- Panel tabs no longer leak into the tab list after a restart: your
  session-store marker, with restored tabs adopted rather than swept.
- The window can never be left resting on a panel's hidden backing tab.
  This is the fix for #4.
- The rail follows Zen's sidebar when it changes side.
- The rail gets out of the way of fullscreen (video and F11).
- The resize handle is visible and hit-testable; colour follows the theme
  or can be set.
- Panel tabs are selected while a panel is open, so password managers and
  other extensions resolve the panel's site - with the parent kept painted.

Features
- Collapse the rail to a hover edge, per window.
- Panel finder: filter the rail by name or URL, and search tabs across
  spaces.
- Back / forward / home controls and per-panel URL memory.
- Configurable shortcut (Ctrl+Alt+1..0 by default).
- "Set current page as home".

Tests
- 8 to 59. The controller runs in Node against a fake chrome window (DOM,
  prefs with observers, gBrowser whose selectedTab fires TabSelect, a
  clock the test drives). Every bug above has a regression test.

ABOUT #4
--------

The mod never matches tabs by URL, so I do not think the ordinary tab was
being mistaken for a panel. What I could reproduce is one step earlier:
when the panel's site is typed into the address bar, Zen offers the hidden
backing tab as a "switch to tab" result, because UrlbarProviderOpenTabs
does not filter hidden tabs. Picking it lands the window on the backing
itself - the page fills the window with no panel around it, and from there
no panel will open, since opening one needs an ordinary tab to anchor to.
The same state was reachable by restarting with a panel open.

The fix is an invariant: the window must never rest on a backing tab. If
a TabSelect lands on one, the selection is handed straight to an ordinary
tab. Covered by tests, including one that fires TabSelect on every
selection the way the browser does, because my first version of that
guard looped.

If your reproduction still fails on this branch, I would like the exact
steps - it means there is a second way in that I have not seen.

AI disclosure, as agreed: built with AI assistance, every change reviewed
by hand, tests run, and in daily use as my only browser.

Feel free to test in local before merging it using my fork if you prefer.

Diego